### PR TITLE
Remove duplicate Schedule cleanup in tests

### DIFF
--- a/tests/ContextPreparator.php
+++ b/tests/ContextPreparator.php
@@ -12,7 +12,6 @@ class ContextPreparator
 		ClassRegistry::init('TimeModeAttempt')->deleteAll(['1 = 1']);
 		ClassRegistry::init('TimeModeSession')->deleteAll(['1 = 1']);
 		ClassRegistry::init('TimeModeRank')->deleteAll(['1 = 1']);
-		ClassRegistry::init('Schedule')->deleteAll(['1 = 1']);
 		ClassRegistry::init('DayRecord')->deleteAll(['1 = 1']);
 		if (!array_key_exists('user', $options) && !array_key_exists('other-users', $options))
 			$this->prepareThisUser(['name' => 'kovarex']);


### PR DESCRIPTION
Remove the redundant second deleteAll call on Schedule in tests/ContextPreparator.php constructor so Schedule is cleared only once.