### PR TITLE
Use absolute URLs for login urls.

### DIFF
--- a/src/View/Sites/index.ctp
+++ b/src/View/Sites/index.ctp
@@ -646,7 +646,7 @@
 						id="g_id_onload"
 						data-client_id="986748597524-05gdpjqrfop96k6haga9gvj1f61sji6v.apps.googleusercontent.com"
 						data-context="signin"
-						data-ux_mode="popup"
+						data-ux_mode="redirect"
 						data-login_uri="<?php echo Router::url('/users/googlesignin', true); ?>"
 						data-auto_prompt="false"
 					></div>

--- a/src/View/Users/add.ctp
+++ b/src/View/Users/add.ctp
@@ -15,7 +15,7 @@
 				id="g_id_onload"
 				data-client_id="986748597524-05gdpjqrfop96k6haga9gvj1f61sji6v.apps.googleusercontent.com"
 				data-context="signin"
-				data-ux_mode="popup"
+				data-ux_mode="redirect"
 				data-login_uri="<?php echo Router::url('/users/googlesignin', true); ?>"
 				data-auto_prompt="false"
 			></div>

--- a/src/View/Users/login.ctp
+++ b/src/View/Users/login.ctp
@@ -26,7 +26,7 @@
 				id="g_id_onload"
 				data-client_id="986748597524-05gdpjqrfop96k6haga9gvj1f61sji6v.apps.googleusercontent.com"
 				data-context="signin"
-				data-ux_mode="popup"
+				data-ux_mode="redirect"
 				data-login_uri="<?php echo Router::url('/users/googlesignin', true); ?>"
 				data-auto_prompt="false"></div>
 			<div


### PR DESCRIPTION
  What changed:
  - popup mode: Opens a popup window, then POSTs cross-origin (Chrome blocks this more aggressively)
  - redirect mode: Full page redirect to Google, then redirects back with POST (more reliable)

The UX is slightly different (full page redirect instead of popup), but it works consistently across all browsers.