### PR TITLE
refactor: Replace session-based login redirect with HMAC-signed URLs

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -1806,15 +1806,19 @@ then ignore this email. https://' . $_SERVER['HTTP_HOST'] . '/users/newpassword/
 		$this->Session->write('page', 'login');
 		$this->Session->write('title', 'Tsumego Hero - Sign In');
 
-		// On GET request, store the referer in session for redirect after login
+		// On GET request, prepare redirect URL with HMAC signature (fully stateless)
 		if (!$this->request->is('post'))
 		{
 			$referer = $this->referer(null, true);
 			// Don't redirect back to login page itself
-			if ($referer && strpos($referer, '/users/login') === false)
-				$this->Session->write('login_redirect', $referer);
-			else
-				$this->Session->delete('login_redirect');
+			$redirectUrl = ($referer && strpos($referer, '/users/login') === false) ? $referer : '/sets/';
+
+			// Sign the redirect URL with HMAC to prevent tampering (no session needed)
+			$signature = $this->signRedirectUrl($redirectUrl);
+
+			// Pass to view for hidden field and Google data-state
+			$this->set('redirectUrl', $redirectUrl);
+			$this->set('redirectSignature', $signature);
 			return null;
 		}
 
@@ -1835,16 +1839,65 @@ then ignore this email. https://' . $_SERVER['HTTP_HOST'] . '/users/newpassword/
 
 		$this->signIn($user);
 
-		// Redirect to the page where user came from, or default to /sets/
-		$redirect = $this->Session->read('login_redirect') ?: '/sets/';
-		$this->Session->delete('login_redirect');
+		// Verify and use redirect URL from POST data
+		$redirect = $this->getVerifiedRedirectUrl(
+			$this->request->data('redirect'),
+			$this->request->data('redirect_signature')
+		);
 		return $this->redirect($redirect);
+	}
+
+	/**
+	 * Sign a redirect URL with HMAC to prevent tampering.
+	 * This allows stateless redirect URL handling without sessions.
+	 */
+	private function signRedirectUrl(string $redirectUrl): string
+	{
+		return hash_hmac('sha256', $redirectUrl, Configure::read('Security.salt'));
+	}
+
+	/**
+	 * Verify redirect URL signature and return safe redirect URL.
+	 * Returns default redirect if signature is invalid or URL is not relative.
+	 */
+	private function getVerifiedRedirectUrl(?string $redirectUrl, ?string $signature): string
+	{
+		$defaultRedirect = '/sets/';
+
+		if (!$redirectUrl || !$signature)
+			return $defaultRedirect;
+
+		// Verify HMAC signature
+		$expectedSignature = $this->signRedirectUrl($redirectUrl);
+		if (!hash_equals($expectedSignature, $signature))
+			return $defaultRedirect;
+
+		// Prevent open redirect attacks - only allow relative URLs
+		if (!$this->isRelativeUrl($redirectUrl))
+			return $defaultRedirect;
+
+		return $redirectUrl;
+	}
+
+	/**
+	 * Check if URL is relative (starts with / but not //)
+	 */
+	private function isRelativeUrl(string $url): bool
+	{
+		return strlen($url) > 0 && $url[0] === '/' && (strlen($url) < 2 || $url[1] !== '/');
 	}
 
 	public function add()
 	{
 		$this->Session->write('page', 'user');
 		$this->Session->write('title', 'Tsumego Hero - Sign Up');
+
+		// Prepare signed redirect URL for Google Sign-In state (fully stateless)
+		$redirectUrl = '/sets/';
+		$signature = $this->signRedirectUrl($redirectUrl);
+		$this->set('redirectUrl', $redirectUrl);
+		$this->set('redirectSignature', $signature);
+
 		if (empty($this->data))
 			return;
 
@@ -2861,9 +2914,20 @@ Joschka Zimdars';
 		}
 		$this->signIn($u);
 
-		// Redirect to the page where user came from, or default to /sets/
-		$redirect = $this->Session->read('login_redirect') ?: '/sets/';
-		$this->Session->delete('login_redirect');
+		// Get redirect URL from state parameter (set via data-state in the button)
+		// Google Sign-In provides built-in CSRF protection via g_csrf_token cookie
+		// We use HMAC signature to prevent redirect URL tampering (stateless)
+		$redirect = '/sets/';
+		$stateJson = $_POST['state'] ?? null;
+		if ($stateJson)
+		{
+			$stateData = json_decode(base64_decode($stateJson), true);
+			if ($stateData)
+				$redirect = $this->getVerifiedRedirectUrl(
+					$stateData['redirect'] ?? null,
+					$stateData['signature'] ?? null
+				);
+		}
 		return $this->redirect($redirect);
 	}
 

--- a/src/View/Sites/index.ctp
+++ b/src/View/Sites/index.ctp
@@ -538,30 +538,6 @@
 			• Longer sessions.<br>
 			• Sign in with Google account.<br>
 			• Option to delete all account related data.<br>
-			<div align="center">
-				<div class="g-signin">
-					<?php if(Auth::isLoggedIn()){ ?>
-					<img src="/img/google-logo.png" title="google-logo" alt="google-logo" width="40px" style="border-radius:25%">
-					<?php }else{ ?>
-					<div
-						id="g_id_onload"
-						data-client_id="986748597524-05gdpjqrfop96k6haga9gvj1f61sji6v.apps.googleusercontent.com"
-						data-context="signin"
-						data-ux_mode="popup"
-						data-login_uri="/users/googlesignin"
-						data-auto_prompt="false"
-					></div>
-					<div
-						class="g_id_signin"
-						data-type="standard"
-						data-shape="rectangular"
-						data-theme="outline"
-						data-text="sign_in_with"
-						data-size="large"
-					></div>
-					<?php } ?>
-				</div>
-			</div>
 		</div>
 		</div>
 

--- a/src/View/Users/add.ctp
+++ b/src/View/Users/add.ctp
@@ -11,6 +11,13 @@
   	You already have an account?<br>
 		<a href="/users/login">Sign In</a><br><br>
 
+		<?php
+		// Encode redirect URL + signature in state for Google Sign-In (stateless)
+		$googleState = base64_encode(json_encode([
+			'redirect' => $redirectUrl,
+			'signature' => $redirectSignature,
+		]));
+		?>
 		<div
 				id="g_id_onload"
 				data-client_id="986748597524-05gdpjqrfop96k6haga9gvj1f61sji6v.apps.googleusercontent.com"
@@ -26,6 +33,7 @@
 				data-theme="outline"
 				data-text="sign_in_with"
 				data-size="large"
+				data-state="<?php echo h($googleState); ?>"
 			></div>
   </div>
 

--- a/src/View/Users/login.ctp
+++ b/src/View/Users/login.ctp
@@ -5,6 +5,8 @@
 			<?php echo $this->Flash->render(); ?>
 			 <h1>Sign in</h1>
 			<?php echo $this->Form->create('User', ['action' => 'login']); ?>
+			<input type="hidden" name="redirect" value="<?php echo h($redirectUrl); ?>"/>
+			<input type="hidden" name="redirect_signature" value="<?php echo h($redirectSignature); ?>"/>
 			<label for="UserName"></label>
 			<div class="input text required">
 				<label for="UserName"></label>
@@ -22,6 +24,13 @@
 			<a href="/users/resetpassword">Reset</a>
 			<br><br>
 
+			<?php
+			// Encode redirect URL + signature in state for Google Sign-In (stateless)
+			$googleState = base64_encode(json_encode([
+				'redirect' => $redirectUrl,
+				'signature' => $redirectSignature,
+			]));
+			?>
 			<div
 				id="g_id_onload"
 				data-client_id="986748597524-05gdpjqrfop96k6haga9gvj1f61sji6v.apps.googleusercontent.com"
@@ -35,7 +44,8 @@
 				data-shape="rectangular"
 				data-theme="outline"
 				data-text="sign_in_with"
-				data-size="large"></div>
+				data-size="large"
+				data-state="<?php echo h($googleState); ?>"></div>
 		</div>
 		<div class="right">
 		</div>


### PR DESCRIPTION
Normally we would pass the redirectUrl to google with csrf token, but that would have to be stored in the session as well, so we have to do this.

I couldn't test the google sign in