### PR TITLE
chore: upgrade ddev from MySQL 8.0 to MariaDB 11.4

### DIFF
--- a/.ddev.example/config.yaml
+++ b/.ddev.example/config.yaml
@@ -9,8 +9,8 @@ xdebug_enabled: true
 additional_hostnames: [test.tsumego]
 additional_fqdns: []
 database:
-    type: mysql
-    version: "8.0"
+    type: mariadb
+    version: "11.4"
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []


### PR DESCRIPTION
- MariaDB 11.4 supports utf8mb4_uca1400_ai_ci collation (needed for production DB)
- MySQL 8.0/8.4 only support up to UCA 9.0 (utf8mb4_0900_ai_ci)
- Production database uses utf8mb4_uca1400_ai_ci which requires MariaDB 11+