### PR TITLE
fix: add Set.id tiebreaker for deterministic ordering

### DIFF
--- a/src/Controller/SetsController.php
+++ b/src/Controller/SetsController.php
@@ -157,7 +157,7 @@ class SetsController extends AppController
 			$set['Set']['image'] = 'b1.png';
 			$set['Set']['difficulty'] = 4;
 			$set['Set']['author'] = 'various creators';
-			$set['Set']['order'] = 999;
+			$set['Set']['order'] = Constants::$DEFAULT_SET_ORDER;
 
 			$this->Set->create();
 			$this->Set->save($set);
@@ -263,7 +263,7 @@ class SetsController extends AppController
 
 		//setTiles
 		$setsRaw = $this->Set->find('all', [
-			'order' => ['Set.order'],
+			'order' => ['Set.order', 'Set.id'],
 			'conditions' => ['public' => 1],
 		]) ?: [];
 		foreach ($setsRaw as $set)

--- a/src/Utility/Constants.php
+++ b/src/Utility/Constants.php
@@ -8,6 +8,8 @@ class Constants
 	// Default tsumego ID for first-time visitors
 	public static int $DEFAULT_TSUMEGO_ID = 15352;
 
+	public static int $DEFAULT_SET_ORDER = 999;
+
 	public static int $LEVEL_MODE = 1;
 	public static int $RATING_MODE = 2;
 	public static int $TIME_MODE = 3;

--- a/src/Utility/SetsSelector.php
+++ b/src/Utility/SetsSelector.php
@@ -184,7 +184,7 @@ partitioned AS (
 
 SELECT *
 FROM partitioned
-ORDER BY order_value, total_count DESC, partition_number
+ORDER BY order_value, total_count DESC, partition_number, id
 ";
 		$rows = Util::query($query);
 		foreach ($rows as $row)

--- a/tests/ContextPreparator.php
+++ b/tests/ContextPreparator.php
@@ -151,7 +151,7 @@ class ContextPreparator
 		$set = [];
 		$set['title'] = Util::extract('title', $setInput) ?: 'Test Set';
 		$set['public'] = Util::extract('public', $setInput) ?? 0;
-		$set['order'] = Util::extract('order', $setInput) ?: 999;
+		$set['order'] = Util::extract('order', $setInput) ?: Constants::$DEFAULT_SET_ORDER;
 		ClassRegistry::init('Set')->create();
 		ClassRegistry::init('Set')->save($set);
 		$this->set = ClassRegistry::init('Set')->find('first', ['order' => 'id DESC'])['Set'];
@@ -426,6 +426,7 @@ class ContextPreparator
 			$set['public'] = is_null($public) ? true : $public;
 			$set['premium'] = $premium;
 			$set['board_theme_index'] = $boardThemeIndex;
+			$set['order'] = Constants::$DEFAULT_SET_ORDER;
 			ClassRegistry::init('Set')->create($set);
 			ClassRegistry::init('Set')->save($set);
 			// reloading so the generated id is retrieved


### PR DESCRIPTION
- ORDER BY Set.order, Set.id in SetsController
- ORDER BY order_value, total_count DESC, partition_number, id in SetsSelector
- Extract Constants::DEFAULT_SET_ORDER  = 999