### PR TITLE
fix: resolve alert overlay by adjusting z-index (forum#92)

### DIFF
--- a/webroot/css/default.css
+++ b/webroot/css/default.css
@@ -377,7 +377,6 @@ li.statusCurrent::before
 	border-radius: 9px;
 	border: 3px solid var(--current-border-color);
 
-	z-index: 20;
 	pointer-events: none;
 }
 
@@ -3892,6 +3891,7 @@ pre {
   font-family: sans-serif;
   font-weight: 400;
   display: none;
+  z-index: 9999;
 }
 #hpIcon1 {
   top: 15px;


### PR DESCRIPTION
add z-index:9999 to .alertBox, just to be sure other z-index > 0 wont interfere
remove z-index:20 from problem border, doesn't seem to do anything

fixes: https://tsumego.com/forums/viewtopic.php?t=92