### PR TITLE
Improve phpBB performance by creating less sessions

### DIFF
--- a/webroot/forums/phpbb/session.php
+++ b/webroot/forums/phpbb/session.php
@@ -795,7 +795,12 @@ class session
 		$_SID = $this->session_id;
 		$this->data = array_merge($this->data, $sql_ary);
 
-		if (!$bot)
+		// Modification: do not create sessions for anonymous users unless required for page functionality
+		if (!$bot && ($this->data['user_id'] != ANONYMOUS
+					  || in_array($this->page['page_name'], array(
+						  "ucp.php",
+						  "app.php/user/forgot_password",
+						  "app.php/user/reset_password" ))))
 		{
 			$cookie_expire = $this->time_now + (($config['max_autologin_time']) ? 86400 * (int) $config['max_autologin_time'] : 31536000);
 


### PR DESCRIPTION
phpBB by default creates a session for every client.  Each session has a database row which needs to be updated on each access.  Modify the session creation logic to avoid creating sessions for anonymous users unless it is necessary.

User sessions still get created when the client access the login or register pages, because at that point a session is required for the forms to function.  This means the session table will still grow unbounded, which can result in performance issues (for us at 100k+ rows).  To solve this, I recommend also setting up a cron job which deletes all anonymous sessions regularly, e.g. weekly:
```
delete from `phpbb_sessions` where `session_user_id`=1;
```