### PR TITLE
fix: limit tsumego board height to prevent giant display (forum#105)

### DIFF
--- a/webroot/besogo/css/besogo.css
+++ b/webroot/besogo/css/besogo.css
@@ -37,6 +37,8 @@
     -moz-user-select: none;      /* Firefox */
     -ms-user-select: none;       /* Internet Explorer/Edge */
      user-select: none;
+     
+    max-height: 70vh;
 }
 
 .besogo-panels {


### PR DESCRIPTION
Fixes forum issue https://tsumego.com/forums/viewtopic.php?t=105

<img src="https://github.com/user-attachments/assets/2de53fc2-6e01-4e8c-96cd-d17337493708"
     width="370" height="719" />

<img src="https://github.com/user-attachments/assets/6822be99-ca2d-46d0-a4de-4b103d2605b8"
     width="645" height="719" />
