### PR TITLE
fix: description always swaps to match visual board color (forum#90)

### DIFF
--- a/changelog/2026-09-02-color-swap-fix.md
+++ b/changelog/2026-09-02-color-swap-fix.md
@@ -1,0 +1,1 @@
+Fixed: When you flip the board, problem descriptions and answer choices now follow the new orientation.

--- a/changelog/2026-09-02-color-swap-fix.md
+++ b/changelog/2026-09-02-color-swap-fix.md
@@ -1,1 +1,1 @@
-Fixed: When you flip the board, problem descriptions and answer choices now follow the new orientation.
+Fixed: When you change the color of tones, problem descriptions and answer choices now follow.

--- a/changelog/2026-09-02-color-swap-fix.md
+++ b/changelog/2026-09-02-color-swap-fix.md
@@ -1,1 +1,1 @@
-Fixed: When you change the color of tones, problem descriptions and answer choices now follow.
+Fixed: When you change the color of your stones, the problem description and answer choices now swap to match.

--- a/changelog/2026-09-02-color-swap-fix.md
+++ b/changelog/2026-09-02-color-swap-fix.md
@@ -1,1 +1,1 @@
-Fixed: When you change the color of your stones, the problem description and answer choices now swap to match.
+Fixed: When you change the color of your stones, the problem description and answer choices now swap to match ([discussion](/forums/viewtopic.php?t=90)).

--- a/db/migrations/20260722182046_replace_b_placeholder_with_black.php
+++ b/db/migrations/20260722182046_replace_b_placeholder_with_black.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Normalize tsumego descriptions to "Black = solver" convention.
+ *
+ * Two steps (order matters!):
+ * 1. Normalize White-first SGF descriptions: swap White<->Black so "solver" is always "Black".
+ *    This runs BEFORE [b] replacement to avoid swapping freshly-inserted "Black" back to "White".
+ * 2. Replace [b] placeholder with "Black" in all descriptions.
+ *
+ * At display time, play.ctp swaps all color words (Black<->White) when the visual stone color
+ * differs from the stored convention, i.e. when $pl != $startingPlayer.
+ */
+final class ReplaceBPlaceholderWithBlack extends AbstractMigration
+{
+	public function up(): void
+	{
+		// Step 1: Normalize White-first SGF descriptions from true-color to "Black = solver".
+		// Must run BEFORE [b]->"Black" replacement, otherwise [b] descriptions on W-first puzzles
+		// would get converted to "Black" then immediately swapped to "White" (393 puzzles affected).
+		//
+		// Swap White<->Black using marker approach with COLLATE utf8mb4_bin for case-sensitive matching:
+		//   1. White -> <<<W>>> (marker), white -> <<<w>>>
+		//   2. Black -> White, black -> white
+		//   3. <<<W>>> -> Black, <<<w>>> -> black
+		//
+		// No REGEXP filter needed: descriptions without color words are unaffected by REPLACE (no-op),
+		// and [b] descriptions have no color words yet (Step 2 hasn't run).
+		// Excludes descriptions already using Black=solver convention for W-first SGFs.
+		// "Black to play" (4 puzzles) and "How does Black answer here?" (1) use "Black" as the solver.
+		// "How should Black attack the marked white stone?" (1) uses "Black"=solver + "white"=literal stone color.
+		// Other Black-only descriptions ("Black's three stones...", "Black maps out...") use "Black"
+		// as the OPPONENT (who IS Black in true-color on W-first), so they are correctly swapped.
+		$this->execute("
+			UPDATE tsumego t
+			JOIN sgf s ON s.tsumego_id = t.id AND s.accepted = 1
+			SET t.description = CONVERT(
+				REPLACE(
+					REPLACE(
+						REPLACE(
+							REPLACE(
+								REPLACE(
+									REPLACE(t.description COLLATE utf8mb4_bin,
+										'White', '<<<W>>>'),
+									'white', '<<<w>>>'),
+								'Black', 'White'),
+							'black', 'white'),
+						'<<<W>>>', 'Black'),
+					'<<<w>>>', 'black')
+				USING utf8mb4)
+			WHERE LOCATE(';W[', s.sgf) > 0
+			  AND (LOCATE(';B[', s.sgf) = 0 OR LOCATE(';W[', s.sgf) < LOCATE(';B[', s.sgf))
+			  AND t.description != ''
+			  AND t.description NOT IN (
+			      'How should Black attack the marked white stone?',
+			      'Black to play',
+			      'How does Black answer here?'
+			  )
+		");
+
+		// Step 2: Replace [b] with "Black" in all descriptions.
+		// Pass 1: "[b] " -> "Black " (preserves existing space after placeholder).
+		// Pass 2: "[b]"  -> "Black " (inserts space for cases like "[b]to play").
+		$this->execute("
+			UPDATE tsumego
+			SET description = REPLACE(REPLACE(description, '[b] ', 'Black '), '[b]', 'Black ')
+			WHERE description LIKE '%[b]%'
+		");
+	}
+
+	public function down(): void
+	{
+		throw new \RuntimeException('This migration cannot be rolled back. Description normalization is irreversible.');
+	}
+}

--- a/db/migrations/20260722182046_replace_b_placeholder_with_black.php
+++ b/db/migrations/20260722182046_replace_b_placeholder_with_black.php
@@ -13,7 +13,7 @@ use Phinx\Migration\AbstractMigration;
  *
  * This matches how SGF comments already work (always true-color).
  *
- * At display time, when the board is inverted ($pl == 1), ALL color words
+ * At display time, when the board is inverted ($swapColors), ALL color words
  * (descriptions, comments, variant answers) are swapped Black<->White
  * so they match what the player sees.
  */
@@ -21,17 +21,24 @@ final class ReplaceBPlaceholderWithBlack extends AbstractMigration
 {
 	public function up(): void
 	{
-		// Step 1: Replace [b] placeholder with the SGF's first move color.
-		// B-first SGFs: [b] -> "Black" (17,854 descriptions)
-		// W-first SGFs: [b] -> "White" (441 descriptions)
+		// Replace [b] placeholder with the SGF's first move color.
+		// The first-move color is taken from the latest accepted SGF per tsumego
+		// (matching how Play.php picks the displayed SGF: order by id DESC).
+		// B-first SGFs: [b] -> "Black"
+		// W-first SGFs: [b] -> "White"
 		//
 		// Pass 1: "[b] " -> "Color " (preserves existing space after placeholder).
 		// Pass 2: "[b]"  -> "Color " (inserts space for cases like "[b]to play").
+		//
+		// Descriptions with no accepted SGF are left untouched: no true color can
+		// be inferred, and the app renders a placeholder SGF for those problems.
 
 		// B-first: [b] -> Black
 		$this->execute("
 			UPDATE tsumego t
-			JOIN sgf s ON s.tsumego_id = t.id AND s.accepted = 1
+			JOIN (SELECT s.tsumego_id, MAX(s.id) AS latest_id FROM sgf s WHERE s.accepted = 1 GROUP BY s.tsumego_id) latest
+			  ON latest.tsumego_id = t.id
+			JOIN sgf s ON s.id = latest.latest_id
 			SET t.description = REPLACE(REPLACE(t.description, '[b] ', 'Black '), '[b]', 'Black ')
 			WHERE t.description LIKE '%[b]%'
 			  AND NOT (
@@ -43,7 +50,9 @@ final class ReplaceBPlaceholderWithBlack extends AbstractMigration
 		// W-first: [b] -> White
 		$this->execute("
 			UPDATE tsumego t
-			JOIN sgf s ON s.tsumego_id = t.id AND s.accepted = 1
+			JOIN (SELECT s.tsumego_id, MAX(s.id) AS latest_id FROM sgf s WHERE s.accepted = 1 GROUP BY s.tsumego_id) latest
+			  ON latest.tsumego_id = t.id
+			JOIN sgf s ON s.id = latest.latest_id
 			SET t.description = REPLACE(REPLACE(t.description, '[b] ', 'White '), '[b]', 'White ')
 			WHERE t.description LIKE '%[b]%'
 			  AND LOCATE(';W[', s.sgf) > 0

--- a/db/migrations/20260722182046_replace_b_placeholder_with_black.php
+++ b/db/migrations/20260722182046_replace_b_placeholder_with_black.php
@@ -5,70 +5,49 @@ declare(strict_types=1);
 use Phinx\Migration\AbstractMigration;
 
 /**
- * Normalize tsumego descriptions to "Black = solver" convention.
+ * Normalize tsumego descriptions to true-color convention.
  *
- * Two steps (order matters!):
- * 1. Normalize White-first SGF descriptions: swap White<->Black so "solver" is always "Black".
- *    This runs BEFORE [b] replacement to avoid swapping freshly-inserted "Black" back to "White".
- * 2. Replace [b] placeholder with "Black" in all descriptions.
+ * True-color means descriptions describe the actual stones on the board:
+ * - B-first SGF: "Black to play" (Black is the solver)
+ * - W-first SGF: "White to play" (White is the solver)
  *
- * At display time, play.ctp swaps all color words (Black<->White) when the visual stone color
- * differs from the stored convention, i.e. when $pl != $startingPlayer.
+ * This matches how SGF comments already work (always true-color).
+ *
+ * At display time, when the board is inverted ($pl == 1), ALL color words
+ * (descriptions, comments, variant answers) are swapped Black<->White
+ * so they match what the player sees.
  */
 final class ReplaceBPlaceholderWithBlack extends AbstractMigration
 {
 	public function up(): void
 	{
-		// Step 1: Normalize White-first SGF descriptions from true-color to "Black = solver".
-		// Must run BEFORE [b]->"Black" replacement, otherwise [b] descriptions on W-first puzzles
-		// would get converted to "Black" then immediately swapped to "White" (393 puzzles affected).
+		// Step 1: Replace [b] placeholder with the SGF's first move color.
+		// B-first SGFs: [b] -> "Black" (17,854 descriptions)
+		// W-first SGFs: [b] -> "White" (441 descriptions)
 		//
-		// Swap White<->Black using marker approach with COLLATE utf8mb4_bin for case-sensitive matching:
-		//   1. White -> <<<W>>> (marker), white -> <<<w>>>
-		//   2. Black -> White, black -> white
-		//   3. <<<W>>> -> Black, <<<w>>> -> black
-		//
-		// No REGEXP filter needed: descriptions without color words are unaffected by REPLACE (no-op),
-		// and [b] descriptions have no color words yet (Step 2 hasn't run).
-		// Excludes descriptions already using Black=solver convention for W-first SGFs.
-		// "Black to play" (4 puzzles) and "How does Black answer here?" (1) use "Black" as the solver.
-		// "How should Black attack the marked white stone?" (1) uses "Black"=solver + "white"=literal stone color.
-		// Other Black-only descriptions ("Black's three stones...", "Black maps out...") use "Black"
-		// as the OPPONENT (who IS Black in true-color on W-first), so they are correctly swapped.
+		// Pass 1: "[b] " -> "Color " (preserves existing space after placeholder).
+		// Pass 2: "[b]"  -> "Color " (inserts space for cases like "[b]to play").
+
+		// B-first: [b] -> Black
 		$this->execute("
 			UPDATE tsumego t
 			JOIN sgf s ON s.tsumego_id = t.id AND s.accepted = 1
-			SET t.description = CONVERT(
-				REPLACE(
-					REPLACE(
-						REPLACE(
-							REPLACE(
-								REPLACE(
-									REPLACE(t.description COLLATE utf8mb4_bin,
-										'White', '<<<W>>>'),
-									'white', '<<<w>>>'),
-								'Black', 'White'),
-							'black', 'white'),
-						'<<<W>>>', 'Black'),
-					'<<<w>>>', 'black')
-				USING utf8mb4)
-			WHERE LOCATE(';W[', s.sgf) > 0
-			  AND (LOCATE(';B[', s.sgf) = 0 OR LOCATE(';W[', s.sgf) < LOCATE(';B[', s.sgf))
-			  AND t.description != ''
-			  AND t.description NOT IN (
-			      'How should Black attack the marked white stone?',
-			      'Black to play',
-			      'How does Black answer here?'
+			SET t.description = REPLACE(REPLACE(t.description, '[b] ', 'Black '), '[b]', 'Black ')
+			WHERE t.description LIKE '%[b]%'
+			  AND NOT (
+			      LOCATE(';W[', s.sgf) > 0
+			      AND (LOCATE(';B[', s.sgf) = 0 OR LOCATE(';W[', s.sgf) < LOCATE(';B[', s.sgf))
 			  )
 		");
 
-		// Step 2: Replace [b] with "Black" in all descriptions.
-		// Pass 1: "[b] " -> "Black " (preserves existing space after placeholder).
-		// Pass 2: "[b]"  -> "Black " (inserts space for cases like "[b]to play").
+		// W-first: [b] -> White
 		$this->execute("
-			UPDATE tsumego
-			SET description = REPLACE(REPLACE(description, '[b] ', 'Black '), '[b]', 'Black ')
-			WHERE description LIKE '%[b]%'
+			UPDATE tsumego t
+			JOIN sgf s ON s.tsumego_id = t.id AND s.accepted = 1
+			SET t.description = REPLACE(REPLACE(t.description, '[b] ', 'White '), '[b]', 'White ')
+			WHERE t.description LIKE '%[b]%'
+			  AND LOCATE(';W[', s.sgf) > 0
+			  AND (LOCATE(';B[', s.sgf) = 0 OR LOCATE(';W[', s.sgf) < LOCATE(';B[', s.sgf))
 		");
 	}
 

--- a/src/Controller/Component/Play.php
+++ b/src/Controller/Component/Play.php
@@ -213,6 +213,17 @@ class Play
 
 		$ogDescription = strip_tags($t['Tsumego']['description'] ?? '');
 		$ogDescription = str_ireplace('[b]', 'Black', $ogDescription);
+		// The OG image renders actual SGF colors (no board inversion), while
+		// descriptions are normalized to "Black = solver". For White-first SGFs,
+		// swap Black<->White so the description matches the OG image.
+		if (TsumegosController::getStartingPlayer($sgf['Sgf']['sgf']) == 1)
+		{
+			$ogDescription = preg_replace_callback(
+				'/\b(Black|black|White|white)\b/',
+				fn($m) => ['Black' => 'White', 'black' => 'white', 'White' => 'Black', 'white' => 'black'][$m[1]],
+				$ogDescription
+			);
+		}
 		$author = $t['Tsumego']['author'] ?? '';
 		if ($author !== '' && $author !== 'Unknown')
 			$ogDescription .= ' - by ' . $author;

--- a/src/Controller/Component/Play.php
+++ b/src/Controller/Component/Play.php
@@ -277,13 +277,35 @@ class Play
 		// about the actual Black/White groups on the board, so the player always
 		// plays black here.
 		// Small boards and specific sets also force black.
+		// The player always plays black; when the SGF is White-first, invert the
+		// board so the player sees black as the side to move, and swap the
+		// true-color description (Black<->White) to match the player's color.
 		if ($tsumegoVariant != null
 			|| ($t['Tsumego']['semeaiType'] ?? 0) != 0
 			|| $checkBSize != 19
 			|| in_array($set['Set']['id'], [109, 233, 236, 239, 243, 244, 246, 251, 253]))
 		{
 			$playerColor = 'black';
-			$swapColors = false;
+			$swapColors = ($sgfColor === 'W');
+		}
+
+		// Optional URL override: ?playercolor=black|white forces the player color,
+		// even for small boards / semeai / variants that normally force black.
+		// No effect when the parameter is absent.
+		if (isset($params['url']['playercolor']))
+		{
+			$requested = strtolower((string) $params['url']['playercolor']);
+			if ($requested === 'white' || $requested === 'black')
+			{
+				$playerColor = $requested;
+				$sgfColor = SgfParser::firstMoveColor($sgf['Sgf']['sgf']);
+				if ($sgfColor === 'W')
+					$swapColors = $playerColor === 'black';
+				elseif ($sgfColor === 'B')
+					$swapColors = $playerColor === 'white';
+				else
+					$swapColors = false;
+			}
 		}
 
 		if (Util::getHealthBasedOnLevel(Auth::getWithDefault('level', 0)) >= 8)

--- a/src/Controller/Component/Play.php
+++ b/src/Controller/Component/Play.php
@@ -184,7 +184,8 @@ class Play
 		$ogTitle .= ' ' . $currentSetConnection['SetConnection']['num'] . '/' . $amountOfOtherCollection;
 
 		$ogDescription = strip_tags($t['Tsumego']['description'] ?? '');
-		$ogDescription = str_ireplace('[b]', 'Black', $ogDescription);
+		// True-color convention: descriptions already match the actual board stones.
+		// The OG image also renders actual SGF colors (no board inversion), so no swap needed.
 		$author = $t['Tsumego']['author'] ?? '';
 		if ($author !== '' && $author !== 'Unknown')
 			$ogDescription .= ' - by ' . $author;

--- a/src/Controller/Component/Play.php
+++ b/src/Controller/Component/Play.php
@@ -217,13 +217,11 @@ class Play
 		// descriptions are normalized to "Black = solver". For White-first SGFs,
 		// swap Black<->White so the description matches the OG image.
 		if (TsumegosController::getStartingPlayer($sgf['Sgf']['sgf']) == 1)
-		{
 			$ogDescription = preg_replace_callback(
 				'/\b(Black|black|White|white)\b/',
 				fn($m) => ['Black' => 'White', 'black' => 'white', 'White' => 'Black', 'white' => 'black'][$m[1]],
 				$ogDescription
 			);
-		}
 		$author = $t['Tsumego']['author'] ?? '';
 		if ($author !== '' && $author !== 'Unknown')
 			$ogDescription .= ' - by ' . $author;

--- a/src/Controller/SgfController.php
+++ b/src/Controller/SgfController.php
@@ -2,6 +2,7 @@
 
 App::uses('AdminActivityLogger', 'Utility');
 App::uses('AdminActivityType', 'Model');
+App::uses('SgfParser', 'Utility');
 App::uses('NotFoundException', 'Routing/Error');
 App::uses('BadRequestException', 'Routing/Error');
 App::uses('ForbiddenException', 'Routing/Error');
@@ -60,15 +61,11 @@ class SgfController extends AppController
 
 	public static function validateSgfFormat(string $sgf): void
 	{
-		$maxSize = 1024 * 1024; // 1 MB
-		if (strlen($sgf) > $maxSize)
-			throw new BadRequestException('SGF data exceeds maximum size of 1 MB.');
+		$error = SgfParser::validate($sgf);
+		if ($error !== null)
+			throw new BadRequestException('Invalid SGF format: ' . $error);
 
-		$trimmed = trim($sgf);
-		if (!str_starts_with($trimmed, '(;'))
-			throw new BadRequestException('Invalid SGF format: must start with "(;".');
-
-		if (!str_contains($trimmed, 'GM[1]'))
+		if (!str_contains($sgf, 'GM[1]'))
 			throw new BadRequestException('Invalid SGF format: must contain GM[1] (Go game marker).');
 	}
 }

--- a/src/Controller/SgfController.php
+++ b/src/Controller/SgfController.php
@@ -65,7 +65,8 @@ class SgfController extends AppController
 		if ($error !== null)
 			throw new BadRequestException('Invalid SGF format: ' . $error);
 
-		if (!str_contains($sgf, 'GM[1]'))
-			throw new BadRequestException('Invalid SGF format: must contain GM[1] (Go game marker).');
+		$gameError = SgfParser::validateGame($sgf);
+		if ($gameError !== null)
+			throw new BadRequestException('Invalid SGF format: ' . $gameError);
 	}
 }

--- a/src/Controller/TsumegosController.php
+++ b/src/Controller/TsumegosController.php
@@ -135,13 +135,13 @@ class TsumegosController extends AppController
 		return $t[$num];
 	}
 
-	public static function getStartingPlayer($sgf)
+	public static function getStartingPlayer($sgf): int
 	{
 		$bStart = strpos($sgf, ';B');
 		$wStart = strpos($sgf, ';W');
-		if ($wStart == 0)
+		if ($wStart === false)
 			return 0;
-		if ($bStart == 0)
+		if ($bStart === false)
 			return 1;
 		if ($bStart <= $wStart)
 			return 0;
@@ -417,10 +417,19 @@ class TsumegosController extends AppController
 			return $this->redirect($this->data['redirect']);
 		}
 
-		if ($tsumego['description'] != $this->data['description'])
+		// Normalize description: the edit form shows the display version (with colors swapped for visual context)
+		$newDescription = $this->data['description'];
+		if (!empty($this->data['color_swapped']))
+			$newDescription = preg_replace_callback(
+				'/\b(Black|black|White|white)\b/',
+				fn($m) => ['Black' => 'White', 'black' => 'white', 'White' => 'Black', 'white' => 'black'][$m[1]],
+				$newDescription
+			);
+
+		if ($tsumego['description'] != $newDescription)
 		{
-			AdminActivityLogger::log(AdminActivityType::DESCRIPTION_EDIT, $tsumegoID, null, $tsumego['description'], $this->data['description']);
-			$tsumego['description'] = $this->data['description'];
+			AdminActivityLogger::log(AdminActivityType::DESCRIPTION_EDIT, $tsumegoID, null, $tsumego['description'], $newDescription);
+			$tsumego['description'] = $newDescription;
 		}
 
 		if ($tsumego['hint'] != $this->data['hint'])

--- a/src/Controller/TsumegosController.php
+++ b/src/Controller/TsumegosController.php
@@ -220,10 +220,19 @@ class TsumegosController extends AppController
 			return $this->redirect($this->data['redirect']);
 		}
 
-		if ($tsumego['description'] != $this->data['description'])
+		// Normalize description: the edit form shows the display version (with colors swapped for visual context)
+		$newDescription = $this->data['description'];
+		if (!empty($this->data['color_swapped']))
+			$newDescription = preg_replace_callback(
+				'/\b(Black|black|White|white)\b/',
+				fn($m) => ['Black' => 'White', 'black' => 'white', 'White' => 'Black', 'white' => 'black'][$m[1]],
+				$newDescription
+			);
+
+		if ($tsumego['description'] != $newDescription)
 		{
-			AdminActivityLogger::log(AdminActivityType::DESCRIPTION_EDIT, $tsumegoID, null, $tsumego['description'], $this->data['description']);
-			$tsumego['description'] = $this->data['description'];
+			AdminActivityLogger::log(AdminActivityType::DESCRIPTION_EDIT, $tsumegoID, null, $tsumego['description'], $newDescription);
+			$tsumego['description'] = $newDescription;
 		}
 
 		if ($tsumego['hint'] != $this->data['hint'])

--- a/src/Utility/SgfParser.php
+++ b/src/Utility/SgfParser.php
@@ -58,6 +58,115 @@ class SgfParser
 		return $blackPos < $whitePos ? 'B' : 'W';
 	}
 
+	/**
+	 * Validate that an SGF string is structurally well-formed for a Go problem.
+	 *
+	 * Catches malformed input that the lenient parsing used elsewhere ignores,
+	 * such as a move node that is not '-'prefixed (e.g. "AB[cc]B[aa]") or a node
+	 * that mixes setup stones with a move.
+	 *
+	 * @param string $sgf
+	 * @return string|null An error description, or null when the SGF is valid.
+	 */
+	public static function validate(string $sgf): ?string
+	{
+		$maxSize = 1024 * 1024; // 1 MB
+		if (strlen($sgf) > $maxSize)
+			return 'SGF data exceeds maximum size of 1 MB.';
+
+		$s = trim($sgf);
+		if ($s === '')
+			return 'SGF data is empty.';
+		if (!str_starts_with($s, '(;'))
+			return 'Invalid SGF: must start with "(;".';
+		if (substr($s, -1) !== ')')
+			return 'Invalid SGF: must end with ")".';
+		if (substr_count($s, '[') !== substr_count($s, ']'))
+			return 'Invalid SGF: unbalanced brackets.';
+
+		$len = strlen($s);
+		$i = 0;
+		$nodeHasSetup = false;
+		$nodeHasMove = false;
+		$inValue = false;
+
+		while ($i < $len)
+		{
+			$ch = $s[$i];
+
+			if ($ch === '[')
+			{
+				$inValue = true;
+				$i++;
+				continue;
+			}
+
+			if ($ch === ']')
+			{
+				$inValue = false;
+				$i++;
+				continue;
+			}
+
+			// Everything inside a property value is opaque; skip it.
+			// In SGF a backslash escapes the next character (e.g. "\[" or "\]"),
+			// so skip that too, otherwise an escaped ']' would end the value.
+			if ($inValue)
+			{
+				if ($ch === '\\')
+				{
+					$i += 2;
+					continue;
+				}
+				$i++;
+				continue;
+			}
+
+			if ($ch === '(' || ctype_space($ch))
+			{
+				$i++;
+				continue;
+			}
+
+			if ($ch === ';')
+			{
+				if ($nodeHasSetup && $nodeHasMove)
+					return 'Invalid SGF: a node cannot contain both setup stones (AB/AW/AE) and a move (B/W).';
+				$nodeHasSetup = false;
+				$nodeHasMove = false;
+				$i++;
+				continue;
+			}
+
+			if ($ch === ')')
+			{
+				if ($nodeHasSetup && $nodeHasMove)
+					return 'Invalid SGF: a node cannot contain both setup stones (AB/AW/AE) and a move (B/W).';
+				$i++;
+				continue;
+			}
+
+			if (ctype_upper($ch))
+			{
+				$start = $i;
+				while ($i < $len && ctype_upper($s[$i]))
+					$i++;
+				$ident = substr($s, $start, $i - $start);
+				if ($i >= $len || $s[$i] !== '[')
+					return "Invalid SGF: property '{$ident}' must be followed by '['.";
+				if ($ident === 'AB' || $ident === 'AW' || $ident === 'AE')
+					$nodeHasSetup = true;
+				if ($ident === 'B' || $ident === 'W')
+					$nodeHasMove = true;
+				continue;
+			}
+
+			return "Invalid SGF: unexpected character '{$ch}' at position {$i}.";
+		}
+
+		return null;
+	}
+
 	private static function detectBoardSize(string $sgf): int
 	{
 		$boardSizePos = strpos($sgf, 'SZ');

--- a/src/Utility/SgfParser.php
+++ b/src/Utility/SgfParser.php
@@ -167,6 +167,78 @@ class SgfParser
 		return null;
 	}
 
+	/**
+	 * Validate that the SGF declares a Go game.
+	 *
+	 * Per the SGF spec the game (GM) property defaults to 1 (Go) when omitted,
+	 * so a missing GM is accepted. Only an explicitly non-Go GM is rejected.
+	 *
+	 * @param string $sgf
+	 * @return string|null An error description, or null when the SGF is a Go game.
+	 */
+	public static function validateGame(string $sgf): ?string
+	{
+		$s = trim($sgf);
+		$len = strlen($s);
+		$i = 0;
+		$inValue = false;
+
+		while ($i < $len)
+		{
+			$ch = $s[$i];
+
+			if ($ch === '[')
+			{
+				$inValue = true;
+				$i++;
+				continue;
+			}
+
+			if ($ch === ']')
+			{
+				$inValue = false;
+				$i++;
+				continue;
+			}
+
+			// Everything inside a property value is opaque; skip it.
+			if ($inValue)
+			{
+				$i++;
+				continue;
+			}
+
+			if ($ch === '\\')
+			{
+				$i += 2;
+				continue;
+			}
+
+			if (ctype_upper($ch))
+			{
+				$start = $i;
+				while ($i < $len && ctype_upper($s[$i]))
+					$i++;
+				$ident = substr($s, $start, $i - $start);
+				if ($ident === 'GM' && $i < $len && $s[$i] === '[')
+				{
+					$i++; // skip '['
+					$valStart = $i;
+					while ($i < $len && $s[$i] !== ']')
+						$i++;
+					$game = substr($s, $valStart, $i - $valStart);
+					if ($game !== '1')
+						return 'Invalid SGF: game (GM) must be Go (1).';
+				}
+				continue;
+			}
+
+			$i++;
+		}
+
+		return null;
+	}
+
 	private static function detectBoardSize(string $sgf): int
 	{
 		$boardSizePos = strpos($sgf, 'SZ');

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -135,19 +135,30 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 		$playerColor[1] = 'BLACK';
 	}
 
+	$swapColorWords = function (string $text): string
+	{
+		return preg_replace_callback(
+			'/\b(Black|black|White|white)\b/',
+			fn($m) => ['Black' => 'White', 'black' => 'white', 'White' => 'Black', 'white' => 'black'][$m[1]],
+			$text
+		);
+	};
+
 	$displayDescription = str_replace('[b]', 'Black ', $t['Tsumego']['description']);
 	// Swap Black<->White in description when the visual stone color differs from the stored convention.
 	// Descriptions are normalized: "Black" always means the solver (the player who moves first).
 	// Swap happens when board inversion ($pl) disagrees with the SGF starting color ($startingPlayer).
 	$shouldSwap = ($pl == 1 && $startingPlayer == 0) || ($pl == 0 && $startingPlayer == 1);
 	if ($shouldSwap)
-	{
-		$displayDescription = preg_replace_callback(
-			'/\b(Black|black|White|white)\b/',
-			fn($m) => ['Black' => 'White', 'black' => 'white', 'White' => 'Black', 'white' => 'black'][$m[1]],
-			$displayDescription
-		);
-	}
+		$displayDescription = $swapColorWords($displayDescription);
+
+	// Variant answers are stored in true colors (they describe the stones on the board as authored).
+	// When the board is inverted ($pl == 1), swap Black<->White so the answers match what the player sees.
+	$displayAnswers = $tv['TsumegoVariant'] ?? null;
+	if ($displayAnswers !== null && $pl == 1)
+		foreach (['answer1', 'answer2', 'answer3', 'answer4'] as $answerKey)
+			if (isset($displayAnswers[$answerKey]))
+				$displayAnswers[$answerKey] = $swapColorWords($displayAnswers[$answerKey]);
 	if ($nothingInRange != false)
 		echo '<div align="center" style="color:red;font-weight:800;">'.$nothingInRange.'</div>';
 	?>
@@ -190,10 +201,11 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 		{
 			if($tv['TsumegoVariant']['type']=='score_estimating')
 			{
+				$capturesLabels = 'Black captures: '.$tv['TsumegoVariant']['answer2'].' | White captures: '.$tv['TsumegoVariant']['answer3'];
+				if ($pl == 1)
+					$capturesLabels = $swapColorWords($capturesLabels);
 				echo '<br>';
-				echo 'Black captures: '.h($tv['TsumegoVariant']['answer2']).' | ';
-				echo 'White captures: '.h($tv['TsumegoVariant']['answer3']).' | ';
-				echo 'Komi: '.h($tv['TsumegoVariant']['answer1']).' ';
+				echo '<span id="scoreEstimatingLabels">'.h($capturesLabels).' | Komi: '.h($tv['TsumegoVariant']['answer1']).'</span>';
 			}
 		}
 		if(Auth::isAdmin()) { ?>
@@ -274,11 +286,11 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 	<div align="center">
 		<?php if($t['Tsumego']['set_id']==262){ ?>
 			<br>
-			<a id="submitScoreEstimatingBlackWins" href="#">Black wins</a>
+			<a id="submitScoreEstimatingBlackWins" href="#"><?php echo $pl == 1 ? 'White wins' : 'Black wins'; ?></a>
 			<?php if(substr($tv['TsumegoVariant']['answer1'],-2) !== '.5') { ?>
 				<a id="submitScoreEstimatingJigo" href="#">Jigo</a>
 			<?php } ?>
-			<a id="submitScoreEstimatingWhiteWins" href="#">White wins</a>
+			<a id="submitScoreEstimatingWhiteWins" href="#"><?php echo $pl == 1 ? 'Black wins' : 'White wins'; ?></a>
 		<?php }else{ ?>
 			<a href="/tsumegos/play/<?php echo $t['Tsumego']['id']; ?>" title="reset problem" id="besogo-next-button">Reset</a>
 			<input value="0" placeholder="Score" type="text" id="ScoreEstimatingSE">
@@ -1953,10 +1965,10 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 		{
 			echo 'options.multipleChoiceCustom = '.json_encode($tv['TsumegoVariant']['type'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).';';
 			echo 'let a5 = [];
-			a5.push('.json_encode($tv['TsumegoVariant']['answer1'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
-			a5.push('.json_encode($tv['TsumegoVariant']['answer2'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
-			a5.push('.json_encode($tv['TsumegoVariant']['answer3'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
-			a5.push('.json_encode($tv['TsumegoVariant']['answer4'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
+			a5.push('.json_encode($displayAnswers['answer1'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
+			a5.push('.json_encode($displayAnswers['answer2'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
+			a5.push('.json_encode($displayAnswers['answer3'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
+			a5.push('.json_encode($displayAnswers['answer4'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
 			customMultipleChoiceAnswer = '.(int)$tv['TsumegoVariant']['numAnswer'].';
 			options.multipleChoiceCustomSetup = a5;';
 		}

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -134,19 +134,20 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 		$playerColor[0] = 'WHITE';
 		$playerColor[1] = 'BLACK';
 	}
-	if($pl==0)
-		$descriptionColor = 'Black ';
-	else
-		$descriptionColor = 'White ';
 
-	if($startingPlayer==1 && $plRand==true)
+	$displayDescription = str_replace('[b]', 'Black ', $t['Tsumego']['description']);
+	// Swap Black<->White in description when the visual stone color differs from the stored convention.
+	// Descriptions are normalized: "Black" always means the solver (the player who moves first).
+	// Swap happens when board inversion ($pl) disagrees with the SGF starting color ($startingPlayer).
+	$shouldSwap = ($pl == 1 && $startingPlayer == 0) || ($pl == 0 && $startingPlayer == 1);
+	if ($shouldSwap)
 	{
-		if($descriptionColor=='Black ')
-			$descriptionColor = 'White ';
-		else if($descriptionColor=='White ')
-			$descriptionColor = 'Black ';
+		$displayDescription = preg_replace_callback(
+			'/\b(Black|black|White|white)\b/',
+			fn($m) => ['Black' => 'White', 'black' => 'white', 'White' => 'Black', 'white' => 'black'][$m[1]],
+			$displayDescription
+		);
 	}
-	$displayDescription = str_replace('[b]', $descriptionColor, $t['Tsumego']['description']);
 	if ($nothingInRange != false)
 		echo '<div align="center" style="color:red;font-weight:800;">'.$nothingInRange.'</div>';
 	?>
@@ -201,14 +202,18 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 			<form id="tsumego-edit" method="post" action="/tsumegos/edit/<?php echo $t['Tsumego']['id']; ?>">
 				<input type="hidden" name="tsumego_id" value="<?php echo $t['Tsumego']['id']; ?>">
 				<input type="hidden" name="redirect" value="<?php echo h($_SERVER['REQUEST_URI']); ?>">
+				<input type="hidden" name="color_swapped" value="<?php echo $shouldSwap ? '1' : '0'; ?>">
 				<table>
 					<tr>
-						<td><label for="description">Desription:</label></td>
-						<td><input type="text" name="description" id="description" value="<?php echo h($t['Tsumego']['description']); ?>"></td>
+						<td><label for="description">Description:</label></td>
+						<td>
+							<textarea name="description" id="description" rows="3" style="width: 100%;"><?php echo h($displayDescription); ?></textarea>
+							<br><small style="color: #888;">Black/White are swapped on save to match the stored convention</small>
+						</td>
 					</tr>
 					<tr>
 						<td><label for="hint">Hint:</label></td>
-						<td><input type="text" name="hint" id="hint" value="<?php echo h($t['Tsumego']['hint']); ?>"></td>
+						<td><textarea name="hint" id="hint" rows="1" style="width: 100%;"><?php echo h($t['Tsumego']['hint']); ?></textarea></td>
 					</tr>
 					<tr>
 						<td><label for="rating">Rating:</label></td>

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -88,8 +88,19 @@
 
 	if(isset($deleteProblem2))
 		echo '<script type="text/javascript">window.location.href = "/sets/view/'.$t['Tsumego']['set_id'].'";</script>';
-	$descriptionColor = $playerColor == 'black' ? 'Black ' : 'White ';
-	$displayDescription = str_replace('[b]', $descriptionColor, $t['Tsumego']['description']);
+	$swapColorWords = function (string $text): string
+	{
+		return preg_replace_callback(
+			'/\b(Black|black|White|white)\b/',
+			fn($m) => ['Black' => 'White', 'black' => 'white', 'White' => 'Black', 'white' => 'black'][$m[1]],
+			$text
+		);
+	};
+	$displayDescription = $t['Tsumego']['description'];
+	// True-color convention: descriptions already match the actual board stones.
+	// When the board is inverted ($swapColors), swap Black<->White to match what the player sees.
+	if ($swapColors)
+		$displayDescription = $swapColorWords($displayDescription);
 	if ($nothingInRange != false)
 		echo '<div align="center" class="status-message">'.$nothingInRange.'</div>';
 	?>
@@ -143,14 +154,18 @@
 			<form id="tsumego-edit" method="post" action="/tsumegos/edit/<?php echo $t['Tsumego']['id']; ?>">
 				<input type="hidden" name="tsumego_id" value="<?php echo $t['Tsumego']['id']; ?>">
 				<input type="hidden" name="redirect" value="<?php echo h($_SERVER['REQUEST_URI']); ?>">
+				<input type="hidden" name="color_swapped" value="<?php echo $shouldSwap ? '1' : '0'; ?>">
 				<table>
 					<tr>
-						<td><label for="description">Desription:</label></td>
-						<td><input type="text" name="description" id="description" value="<?php echo h($t['Tsumego']['description']); ?>"></td>
+						<td><label for="description">Description:</label></td>
+						<td>
+							<textarea name="description" id="description" rows="3" style="width: 100%;"><?php echo h($displayDescription); ?></textarea>
+							<br><small style="color: #888;">Black/White are swapped on save to match the stored convention</small>
+						</td>
 					</tr>
 					<tr>
 						<td><label for="hint">Hint:</label></td>
-						<td><input type="text" name="hint" id="hint" value="<?php echo h($t['Tsumego']['hint']); ?>"></td>
+						<td><textarea name="hint" id="hint" rows="1" style="width: 100%;"><?php echo h($t['Tsumego']['hint']); ?></textarea></td>
 					</tr>
 					<tr>
 						<td><label for="rating">Rating:</label></td>

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -169,7 +169,7 @@
 						<td><label for="description">Description:</label></td>
 						<td>
 							<textarea name="description" id="description" rows="3" style="width: 100%;"><?php echo h($displayDescription); ?></textarea>
-							<br><small style="color: #888;">Black/White are swapped on save to match the stored convention</small>
+							<br><small style="color: #888;">Describe the problem. <?php echo ($playerColor === 'white') ? 'White' : 'Black'; ?> is to move.</small>
 						</td>
 					</tr>
 					<tr>

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -101,6 +101,14 @@
 	// When the board is inverted ($swapColors), swap Black<->White to match what the player sees.
 	if ($swapColors)
 		$displayDescription = $swapColorWords($displayDescription);
+
+	// Variant answers are stored in true colors (they describe the stones on the board as authored).
+	// When the board is inverted ($swapColors), swap Black<->White so the answers match what the player sees.
+	$displayAnswers = $tv['TsumegoVariant'] ?? null;
+	if ($displayAnswers !== null && $swapColors)
+		foreach (['answer1', 'answer2', 'answer3', 'answer4'] as $answerKey)
+			if (isset($displayAnswers[$answerKey]))
+				$displayAnswers[$answerKey] = $swapColorWords($displayAnswers[$answerKey]);
 	if ($nothingInRange != false)
 		echo '<div align="center" class="status-message">'.$nothingInRange.'</div>';
 	?>
@@ -142,10 +150,11 @@
 		{
 			if($tv['TsumegoVariant']['type']=='score_estimating')
 			{
+				$capturesLabels = 'Black captures: '.$tv['TsumegoVariant']['answer2'].' | White captures: '.$tv['TsumegoVariant']['answer3'];
+				if ($pl == 1)
+					$capturesLabels = $swapColorWords($capturesLabels);
 				echo '<br>';
-				echo 'Black captures: '.h($tv['TsumegoVariant']['answer2']).' | ';
-				echo 'White captures: '.h($tv['TsumegoVariant']['answer3']).' | ';
-				echo 'Komi: '.h($tv['TsumegoVariant']['answer1']).' ';
+				echo '<span id="scoreEstimatingLabels">'.h($capturesLabels).' | Komi: '.h($tv['TsumegoVariant']['answer1']).'</span>';
 			}
 		}
 		if(Auth::isAdmin()) { ?>
@@ -222,11 +231,11 @@
 	<div align="center">
 		<?php if($t['Tsumego']['set_id']==262){ ?>
 			<br>
-			<a id="submitScoreEstimatingBlackWins" href="#">Black wins</a>
+			<a id="submitScoreEstimatingBlackWins" href="#"><?php echo $pl == 1 ? 'White wins' : 'Black wins'; ?></a>
 			<?php if(substr($tv['TsumegoVariant']['answer1'],-2) !== '.5') { ?>
 				<a id="submitScoreEstimatingJigo" href="#">Jigo</a>
 			<?php } ?>
-			<a id="submitScoreEstimatingWhiteWins" href="#">White wins</a>
+			<a id="submitScoreEstimatingWhiteWins" href="#"><?php echo $pl == 1 ? 'Black wins' : 'White wins'; ?></a>
 		<?php }else{ ?>
 			<a href="/<?php echo $setConnection['SetConnection']['id']; ?>" title="reset problem" id="besogo-next-button">Reset</a>
 			<input value="0" placeholder="Score" type="text" id="ScoreEstimatingSE">
@@ -1773,10 +1782,10 @@
 		{
 			echo 'options.multipleChoiceCustom = '.json_encode($tv['TsumegoVariant']['type'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).';';
 			echo 'let a5 = [];
-			a5.push('.json_encode($tv['TsumegoVariant']['answer1'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
-			a5.push('.json_encode($tv['TsumegoVariant']['answer2'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
-			a5.push('.json_encode($tv['TsumegoVariant']['answer3'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
-			a5.push('.json_encode($tv['TsumegoVariant']['answer4'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
+			a5.push('.json_encode($displayAnswers['answer1'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
+			a5.push('.json_encode($displayAnswers['answer2'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
+			a5.push('.json_encode($displayAnswers['answer3'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
+			a5.push('.json_encode($displayAnswers['answer4'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE).');
 			customMultipleChoiceAnswer = '.(int)$tv['TsumegoVariant']['numAnswer'].';
 			options.multipleChoiceCustomSetup = a5;';
 		}

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -151,7 +151,7 @@
 			if($tv['TsumegoVariant']['type']=='score_estimating')
 			{
 				$capturesLabels = 'Black captures: '.$tv['TsumegoVariant']['answer2'].' | White captures: '.$tv['TsumegoVariant']['answer3'];
-				if ($pl == 1)
+				if ($swapColors)
 					$capturesLabels = $swapColorWords($capturesLabels);
 				echo '<br>';
 				echo '<span id="scoreEstimatingLabels">'.h($capturesLabels).' | Komi: '.h($tv['TsumegoVariant']['answer1']).'</span>';
@@ -163,7 +163,7 @@
 			<form id="tsumego-edit" method="post" action="/tsumegos/edit/<?php echo $t['Tsumego']['id']; ?>">
 				<input type="hidden" name="tsumego_id" value="<?php echo $t['Tsumego']['id']; ?>">
 				<input type="hidden" name="redirect" value="<?php echo h($_SERVER['REQUEST_URI']); ?>">
-				<input type="hidden" name="color_swapped" value="<?php echo $shouldSwap ? '1' : '0'; ?>">
+				<input type="hidden" name="color_swapped" value="<?php echo $swapColors ? '1' : '0'; ?>">
 				<table>
 					<tr>
 						<td><label for="description">Description:</label></td>
@@ -231,11 +231,11 @@
 	<div align="center">
 		<?php if($t['Tsumego']['set_id']==262){ ?>
 			<br>
-			<a id="submitScoreEstimatingBlackWins" href="#"><?php echo $pl == 1 ? 'White wins' : 'Black wins'; ?></a>
+			<a id="submitScoreEstimatingBlackWins" href="#"><?php echo $swapColors ? 'White wins' : 'Black wins'; ?></a>
 			<?php if(substr($tv['TsumegoVariant']['answer1'],-2) !== '.5') { ?>
 				<a id="submitScoreEstimatingJigo" href="#">Jigo</a>
 			<?php } ?>
-			<a id="submitScoreEstimatingWhiteWins" href="#"><?php echo $pl == 1 ? 'Black wins' : 'White wins'; ?></a>
+			<a id="submitScoreEstimatingWhiteWins" href="#"><?php echo $swapColors ? 'Black wins' : 'White wins'; ?></a>
 		<?php }else{ ?>
 			<a href="/<?php echo $setConnection['SetConnection']['id']; ?>" title="reset problem" id="besogo-next-button">Reset</a>
 			<input value="0" placeholder="Score" type="text" id="ScoreEstimatingSE">

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -825,8 +825,8 @@
 				hasChosen = true;
 				locked = true;
 				$("#ScoreEstimatingSE").prop("disabled", true);
-				$("#besogo-se-black").css("background-color", color);
-				$("#besogo-se-white").css("background-color", color);
+				$("#besogo-score-wins-a").css("background-color", color);
+				$("#besogo-score-wins-b").css("background-color", color);
 				$("#besogo-se-more").css("background-color", color);
 				$("#besogo-se-less").css("background-color", color);
 				$("#submitScoreEstimatingSE").css("background-color", color);
@@ -1822,7 +1822,7 @@
 	var showComment = function(commentText)
 		{
 			$("#theComment").css("display", commentText.length == 0 ? "none" : "block");
-			$("#theComment").text(commentText);
+			$("#theComment").text(besogo.boardInverted ? besogo.swapColorWords(commentText) : commentText);
 		};
 	besogo.editor.registerShowComment(showComment);
 	showComment(besogo.editor.getCurrent().comment || '');

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -825,8 +825,8 @@
 				hasChosen = true;
 				locked = true;
 				$("#ScoreEstimatingSE").prop("disabled", true);
-				$("#besogo-se-winner-black").css("background-color", color);
-				$("#besogo-se-winner-white").css("background-color", color);
+				$("#besogo-se-black").css("background-color", color);
+				$("#besogo-se-white").css("background-color", color);
 				$("#besogo-se-more").css("background-color", color);
 				$("#besogo-se-less").css("background-color", color);
 				$("#submitScoreEstimatingSE").css("background-color", color);

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -825,8 +825,8 @@
 				hasChosen = true;
 				locked = true;
 				$("#ScoreEstimatingSE").prop("disabled", true);
-				$("#besogo-score-wins-a").css("background-color", color);
-				$("#besogo-score-wins-b").css("background-color", color);
+				$("#besogo-se-winner-black").css("background-color", color);
+				$("#besogo-se-winner-white").css("background-color", color);
 				$("#besogo-se-more").css("background-color", color);
 				$("#besogo-se-less").css("background-color", color);
 				$("#submitScoreEstimatingSE").css("background-color", color);

--- a/tests/ContextPreparator.php
+++ b/tests/ContextPreparator.php
@@ -1,6 +1,7 @@
 <?php
 
 App::uses('BoardSelector', 'Utility');
+App::uses('SgfParser', 'Utility');
 
 class ContextPreparator
 {
@@ -258,6 +259,7 @@ class ContextPreparator
 		ClassRegistry::init('Sgf')->create($sgf);
 		$sgf['tsumego_id'] = $tsumego['id'];
 		$sgf['sgf'] = Util::extract('data', $tsumegoSgf);
+		$this->validateFixtureSgf($sgf['sgf'], $tsumego['id']);
 		$sgf['accepted'] = Util::extractWithDefault('accepted', $tsumegoSgf, true);
 		$sgf['correct_moves'] = Util::extract('correct_moves', $tsumegoSgf);
 		$sgf['first_move_color'] = Util::extract('first_move_color', $tsumegoSgf);
@@ -268,6 +270,16 @@ class ContextPreparator
 		$savedSgf['id'] = $sgfModel->id;
 		$tsumego['sgfs'][] = $savedSgf;
 		$this->checkOptionsConsumed($tsumegoSgf);
+	}
+
+	private function validateFixtureSgf(string $sgf, int $tsumegoId): void
+	{
+		$error = SgfParser::validate($sgf);
+		if ($error !== null)
+			throw new Exception("Invalid fixture SGF for tsumego {$tsumegoId}: {$error}");
+
+		if (!str_contains($sgf, 'GM[1]'))
+			throw new Exception("Invalid fixture SGF for tsumego {$tsumegoId}: must contain GM[1] (Go game marker).");
 	}
 
 	private function prepareTsumegoSgfs(?array $tsumegoSgfs, &$tsumego): void

--- a/tests/ContextPreparator.php
+++ b/tests/ContextPreparator.php
@@ -177,6 +177,11 @@ class ContextPreparator
 		$tsumego['maximum_rating'] = Util::extract('maximum_rating', $tsumegoInput) ?: null;
 		$tsumego['alternative_response'] = Util::extract('alternative_response', $tsumegoInput) ?? 1;
 		$tsumego['pass'] = Util::extract('pass', $tsumegoInput) ?? 0;
+		$tsumego['semeaiType'] = Util::extract('semeai_type', $tsumegoInput);
+		$tsumego['minLib'] = Util::extract('min_lib', $tsumegoInput);
+		$tsumego['maxLib'] = Util::extract('max_lib', $tsumegoInput);
+		$tsumego['libertyCount'] = Util::extract('liberty_count', $tsumegoInput);
+		$tsumego['variance'] = Util::extract('variance', $tsumegoInput);
 		$tsumego['deleted'] = Util::extract('deleted', $tsumegoInput);
 		$tsumego['author'] = Util::extract('author', $tsumegoInput) ?: '';
 		ClassRegistry::init('Tsumego')->create($tsumego);

--- a/tests/ContextPreparator.php
+++ b/tests/ContextPreparator.php
@@ -195,6 +195,7 @@ class ContextPreparator
 		$this->prepareTsumegoSgfs(Util::extract('sgfs', $tsumegoInput), $tsumego);
 		$this->prepareTsumegoComments(Util::extract('comments', $tsumegoInput), $tsumego);
 		$this->prepareTsumegoIssues(Util::extract('issues', $tsumegoInput), $tsumego);
+		$this->prepareTsumegoVariants(Util::extract('variants', $tsumegoInput), $tsumego);
 		$this->checkOptionsConsumed($tsumegoInput);
 		return $tsumego;
 	}
@@ -326,6 +327,25 @@ class ContextPreparator
 			$this->prepareTsumegoComment(['message' => $message], $tsumego, $issueId);
 
 		$this->checkOptionsConsumed($issueInput);
+	}
+
+	private function prepareTsumegoVariants(?array $tsumegoVariants, &$tsumego): void
+	{
+		if (!$tsumegoVariants)
+			return;
+		foreach ($tsumegoVariants as $variantInput)
+			$this->prepareTsumegoVariant($variantInput, $tsumego);
+	}
+
+	private function prepareTsumegoVariant(array $variantInput, &$tsumego): void
+	{
+		$variant = array_merge(['tsumego_id' => $tsumego['id']], $variantInput);
+		$variantModel = ClassRegistry::init('TsumegoVariant');
+		$variantModel->create($variant);
+		$variantModel->save($variant);
+		$savedVariant = $variantModel->data['TsumegoVariant'];
+		$savedVariant['id'] = $variantModel->id;
+		$tsumego['variants'][] = $savedVariant;
 	}
 
 	private function prepareTsumegoStatuses($tsumegoStatuses, $tsumego): void

--- a/tests/ContextPreparator.php
+++ b/tests/ContextPreparator.php
@@ -278,8 +278,9 @@ class ContextPreparator
 		if ($error !== null)
 			throw new Exception("Invalid fixture SGF for tsumego {$tsumegoId}: {$error}");
 
-		if (!str_contains($sgf, 'GM[1]'))
-			throw new Exception("Invalid fixture SGF for tsumego {$tsumegoId}: must contain GM[1] (Go game marker).");
+		$gameError = SgfParser::validateGame($sgf);
+		if ($gameError !== null)
+			throw new Exception("Invalid fixture SGF for tsumego {$tsumegoId}: {$gameError}");
 	}
 
 	private function prepareTsumegoSgfs(?array $tsumegoSgfs, &$tsumego): void

--- a/tests/TestCase/Controller/DefaultPlayerColorTest.php
+++ b/tests/TestCase/Controller/DefaultPlayerColorTest.php
@@ -14,7 +14,7 @@ class DefaultPlayerColorTest extends TestCaseWithAuth
 		Auth::logout();
 		$context = new ContextPreparator([
 			'user' => ['name' => 'originalUser'],
-			'tsumego' => ['sets' => [['name' => 'originalUserSet', 'num' => 1]], 'description' => '[b]to play.', 'sgf' => ['data' => '(;GM[1]FF[4]SZ[19];B[aa])']],
+			'tsumego' => ['sets' => [['name' => 'originalUserSet', 'num' => 1]], 'description' => 'Black to play.', 'sgf' => ['data' => '(;GM[1]FF[4]SZ[19];B[aa])']],
 		]);
 		$this->login('originalUser');
 		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
@@ -36,7 +36,7 @@ class DefaultPlayerColorTest extends TestCaseWithAuth
 			'user' => ['name' => 'originalUserWhite'],
 			'tsumego' => [
 				'sets' => [['name' => 'originalUserWhiteSet', 'num' => 1]],
-				'description' => '[b]to play.',
+				'description' => 'White to play.',
 				'sgf' => ['data' => '(;GM[1]FF[4]SZ[19];W[aa])'],
 			],
 		]);
@@ -60,7 +60,7 @@ class DefaultPlayerColorTest extends TestCaseWithAuth
 			'user' => ['name' => 'smallBoard'],
 			'tsumego' => [
 				'sets' => [['name' => '9x9 Test Set', 'num' => 1]],
-				'description' => '[b]to play.',
+				'description' => 'White to play.',
 				'sgf' => ['data' => '(;GM[1]FF[4]SZ[9];W[aa])'],
 			],
 		]);
@@ -73,7 +73,7 @@ class DefaultPlayerColorTest extends TestCaseWithAuth
 		);
 
 		$this->assertTextContains('options.playerColor = "black"', $this->view);
-		$this->assertTextContains('options.swapColors = false', $this->view);
+		$this->assertTextContains('options.swapColors = true', $this->view);
 		$this->assertTextContains('Black to play.', $this->view);
 	}
 

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -783,4 +783,261 @@ class TsumegosControllerTest extends TestCaseWithAuth
 
 		$this->assertMatchesRegularExpression('/"diff":"[a-z]+"/', $result);
 	}
+
+	public static function descriptionColorSwapProvider(): array
+	{
+		$blackFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])';
+		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
+
+		return [
+			'no swap: Black visual (pl=0) + Black-first SGF' => [
+				"Black's stones attack White's group. black wins!",
+				$blackFirstSgf,
+				'black',
+				"Black's stones attack White's group. black wins!",
+			],
+			'swap: White visual (pl=1) + Black-first SGF, preserves word boundaries' => [
+				"Black's stones. Kill the white group near the Blackbird. Watch whitespace.",
+				$blackFirstSgf,
+				'white',
+				"White's stones. Kill the black group near the Blackbird. Watch whitespace.",
+			],
+			'swap: Black visual (pl=0) + White-first SGF, normalized Black swaps to White' => [
+				"Black to play. Attack the white group.",
+				$whiteFirstSgf,
+				'black',
+				"White to play. Attack the black group.",
+			],
+			'no swap: White visual (pl=1) + White-first SGF, normalized Black stays' => [
+				"Black to play. Attack the white group.",
+				$whiteFirstSgf,
+				'white',
+				"Black to play. Attack the white group.",
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider descriptionColorSwapProvider
+	 */
+	public function testDescriptionColorSwap(string $description, string $sgf, string $playerColor, string $expected): void
+	{
+		$context = new ContextPreparator([
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => $description,
+				'sgf' => $sgf,
+			]
+		]);
+
+		$this->testAction(
+			'tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=' . $playerColor,
+			['return' => 'view']
+		);
+
+		$decoded = htmlspecialchars_decode(strip_tags($this->view));
+		$this->assertStringContainsString($expected, $decoded);
+	}
+
+	/**
+	 * Browser test: Admin edits description on a puzzle where colors are swapped.
+	 * W-first SGF + playercolor=black -> swap active -> textarea shows swapped text.
+	 * After editing and saving, the stored description is normalized back (Black = solver).
+	 */
+	public function testDescriptionEditWithSwap(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['admin' => true],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to attack the white stones.',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])'
+			]
+		]);
+
+		$browser = Browser::instance();
+		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
+		// W-first SGF + playercolor=black -> pl=0, sP=1 -> shouldSwap=true
+		$browser->get($setConnectionId . '?playercolor=black');
+
+		// Click the (Edit) link to reveal the form
+		$browser->clickId('modify-description');
+
+		// Verify the textarea shows swapped text (Black->White for display)
+		$textarea = $browser->find('#description');
+		$this->assertSame('White to attack the black stones.', $textarea->getAttribute('value'));
+
+		// Verify hidden color_swapped field is 1
+		$colorSwapped = $browser->find('input[name="color_swapped"]');
+		$this->assertSame('1', $colorSwapped->getAttribute('value'));
+
+		// Edit the description to something new (still in swapped/display form)
+		$textarea->clear();
+		$textarea->sendKeys('White to play here.');
+
+		// Submit the form
+		$browser->clickId('tsumego-edit-submit');
+
+		// Verify the stored description was normalized (White->Black)
+		$saved = ClassRegistry::init('Tsumego')->findById($context->tsumegos[0]['id']);
+		$this->assertSame('Black to play here.', $saved['Tsumego']['description']);
+	}
+
+	/**
+	 * Browser test: Admin edits description on a puzzle where colors are NOT swapped.
+	 * B-first SGF + playercolor=black -> no swap -> textarea shows original text.
+	 * After editing and saving, the stored description is kept as-is.
+	 */
+	public function testDescriptionEditNoSwap(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['admin' => true],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to attack the white stones.',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])'
+			]
+		]);
+
+		$browser = Browser::instance();
+		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
+		// B-first SGF + playercolor=black -> pl=0, sP=0 -> shouldSwap=false
+		$browser->get($setConnectionId . '?playercolor=black');
+
+		// Click the (Edit) link to reveal the form
+		$browser->clickId('modify-description');
+
+		// Verify the textarea shows original text (no swap)
+		$textarea = $browser->find('#description');
+		$this->assertSame('Black to attack the white stones.', $textarea->getAttribute('value'));
+
+		// Verify hidden color_swapped field is 0
+		$colorSwapped = $browser->find('input[name="color_swapped"]');
+		$this->assertSame('0', $colorSwapped->getAttribute('value'));
+
+		// Edit the description
+		$textarea->clear();
+		$textarea->sendKeys('Black to play first.');
+
+		// Submit the form
+		$browser->clickId('tsumego-edit-submit');
+
+		// Verify it was stored as-is (no normalization needed)
+		$saved = ClassRegistry::init('Tsumego')->findById($context->tsumegos[0]['id']);
+		$this->assertSame('Black to play first.', $saved['Tsumego']['description']);
+	}
+
+	public static function startingPlayerProvider(): array
+	{
+		return [
+			'Black first' => ['(;GM[1]FF[4]SZ[19];B[aa];W[ab])', 0],
+			'White first' => ['(;GM[1]FF[4]SZ[19];W[aa];B[ab])', 1],
+			'Black only' => ['(;GM[1]FF[4]SZ[19];B[aa])', 0],
+			'White only' => ['(;GM[1]FF[4]SZ[19];W[aa])', 1],
+		];
+	}
+
+	/**
+	 * @dataProvider startingPlayerProvider
+	 */
+	public function testGetStartingPlayer(string $sgf, int $expected): void
+	{
+		$this->assertSame($expected, TsumegosController::getStartingPlayer($sgf));
+	}
+
+	/**
+	 * Browser test: For a White-first SGF, check what color the player actually places
+	 * and whether the description matches that visual color.
+	 *
+	 * Key insight: besogoPlayerColor controls board INVERSION, not the player's stone color.
+	 * The player's visual stone color is: besogo.editor.getCurrent().nextMove()
+	 *   -1 = Black stone on screen, 1 = White stone on screen
+	 *
+	 * When besogoPlayerColor="white" (inversion active):
+	 *   White-first SGF -> firstMove inverted to BLACK -> player places BLACK stones visually
+	 * When besogoPlayerColor="black" (no inversion):
+	 *   White-first SGF -> firstMove stays WHITE -> player places WHITE stones visually
+	 *
+	 * The description should match the VISUAL stone color the player places.
+	 * Under normalized convention, description stores "Black to play".
+	 * The swap formula ($pl != $startingPlayer) ensures correct visual match.
+	 */
+	public function testDescriptionMatchesActualFirstMoveColor(): void
+	{
+		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
+
+		// Normalized convention: "Black to play" stored for ALL puzzles (Black = solver)
+		$context = new ContextPreparator([
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to play',
+				'sgf' => $whiteFirstSgf,
+			],
+		]);
+
+		$browser = Browser::instance();
+		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
+
+		for ($i = 0; $i < 10; $i++)
+		{
+			$browser->get((string) $setConnectionId);
+
+			$descriptionText = $browser->find('#descriptionText')->getText();
+			$besogoColor = $browser->driver->executeScript("return besogoPlayerColor;");
+
+			// Wait for besogo to initialize
+			$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
+			$wait->until(function () use ($browser) {
+				return $browser->driver->executeScript("return typeof besogo !== 'undefined' && besogo.editor !== undefined;");
+			});
+
+			// nextMove() returns -1 (BLACK) or 1 (WHITE) -- the ACTUAL visual stone color
+			$nextMove = $browser->driver->executeScript("return besogo.editor.getCurrent().nextMove();");
+			$visualStoneColor = ($nextMove === -1) ? 'Black' : 'White';
+
+			$descriptionSaysBlack = str_contains($descriptionText, 'Black');
+			$descriptionSaysWhite = str_contains($descriptionText, 'White');
+
+			// The description color should match the visual stone color
+			$this->assertTrue(
+				($visualStoneColor === 'Black' && $descriptionSaysBlack)
+				|| ($visualStoneColor === 'White' && $descriptionSaysWhite),
+				"Iteration $i: description='$descriptionText', visual stone=$visualStoneColor, besogoPlayerColor=$besogoColor"
+			);
+		}
+	}
+
+	/**
+	 * OG description should swap Black/White for White-first SGFs,
+	 * since the OG image always renders actual SGF stone colors.
+	 */
+	public function testOgDescriptionSwapsColorForWhiteFirstSgf(): void
+	{
+		$blackFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])';
+		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
+
+		// Black-first: OG description keeps "Black" (no swap)
+		$context = new ContextPreparator([
+			'tsumego' => ['set_order' => 1, 'description' => 'Black to capture the white group', 'sgf' => $blackFirstSgf],
+		]);
+		$result = $this->testAction(
+			'tsumegos/play/' . $context->tsumegos[0]['id'],
+			['return' => 'contents']
+		);
+		preg_match('/property="og:description"\s+content="([^"]*)"/', $result, $m);
+		$this->assertNotEmpty($m, 'og:description should exist for Black-first SGF');
+		$this->assertStringContainsString('Black to capture the white group', $m[1]);
+
+		// White-first: OG description swaps "Black" -> "White"
+		$context2 = new ContextPreparator([
+			'tsumego' => ['set_order' => 1, 'description' => 'Black to capture the white group', 'sgf' => $whiteFirstSgf],
+		]);
+		$result2 = $this->testAction(
+			'tsumegos/play/' . $context2->tsumegos[0]['id'],
+			['return' => 'contents']
+		);
+		preg_match('/property="og:description"\s+content="([^"]*)"/', $result2, $m2);
+		$this->assertNotEmpty($m2, 'og:description should exist for White-first SGF');
+		$this->assertStringContainsString('White to capture the black group', $m2[1]);
+	}
 }

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -790,26 +790,26 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
 
 		return [
-			'no swap: Black visual (pl=0) + Black-first SGF' => [
+			'no swap: Black visual (pl=0) + Black-first SGF, true-color matches' => [
 				"Black's stones attack White's group. black wins!",
 				$blackFirstSgf,
 				'black',
 				"Black's stones attack White's group. black wins!",
 			],
-			'swap: White visual (pl=1) + Black-first SGF, preserves word boundaries' => [
+			'swap: White visual (pl=1) + Black-first SGF, board inverted' => [
 				"Black's stones. Kill the white group near the Blackbird. Watch whitespace.",
 				$blackFirstSgf,
 				'white',
 				"White's stones. Kill the black group near the Blackbird. Watch whitespace.",
 			],
-			'swap: Black visual (pl=0) + White-first SGF, normalized Black swaps to White' => [
-				"Black to play. Attack the white group.",
+			'no swap: Black visual (pl=0) + White-first SGF, true-color matches' => [
+				"White to play. Attack the black group.",
 				$whiteFirstSgf,
 				'black',
 				"White to play. Attack the black group.",
 			],
-			'no swap: White visual (pl=1) + White-first SGF, normalized Black stays' => [
-				"Black to play. Attack the white group.",
+			'swap: White visual (pl=1) + White-first SGF, board inverted' => [
+				"White to play. Attack the black group.",
 				$whiteFirstSgf,
 				'white',
 				"Black to play. Attack the white group.",
@@ -840,9 +840,9 @@ class TsumegosControllerTest extends TestCaseWithAuth
 	}
 
 	/**
-	 * Browser test: Admin edits description on a puzzle where colors are swapped.
-	 * W-first SGF + playercolor=black -> swap active -> textarea shows swapped text.
-	 * After editing and saving, the stored description is normalized back (Black = solver).
+	 * Browser test: Admin edits description on a puzzle where board is inverted.
+	 * W-first SGF + playercolor=white -> board inverted -> textarea shows swapped text.
+	 * After editing and saving, the stored description is un-swapped back to true-color.
 	 */
 	public function testDescriptionEditWithSwap(): void
 	{
@@ -850,22 +850,22 @@ class TsumegosControllerTest extends TestCaseWithAuth
 			'user' => ['admin' => true],
 			'tsumego' => [
 				'set_order' => 1,
-				'description' => 'Black to attack the white stones.',
+				'description' => 'White to attack the black stones.',
 				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])'
 			]
 		]);
 
 		$browser = Browser::instance();
 		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
-		// W-first SGF + playercolor=black -> pl=0, sP=1 -> shouldSwap=true
-		$browser->get($setConnectionId . '?playercolor=black');
+		// W-first SGF + playercolor=white -> pl=1 -> shouldSwap=true
+		$browser->get($setConnectionId . '?playercolor=white');
 
 		// Click the (Edit) link to reveal the form
 		$browser->clickId('modify-description');
 
-		// Verify the textarea shows swapped text (Black->White for display)
+		// Verify the textarea shows swapped text (White->Black for inverted display)
 		$textarea = $browser->find('#description');
-		$this->assertSame('White to attack the black stones.', $textarea->getAttribute('value'));
+		$this->assertSame('Black to attack the white stones.', $textarea->getAttribute('value'));
 
 		// Verify hidden color_swapped field is 1
 		$colorSwapped = $browser->find('input[name="color_swapped"]');
@@ -873,19 +873,19 @@ class TsumegosControllerTest extends TestCaseWithAuth
 
 		// Edit the description to something new (still in swapped/display form)
 		$textarea->clear();
-		$textarea->sendKeys('White to play here.');
+		$textarea->sendKeys('Black to play here.');
 
 		// Submit the form
 		$browser->clickId('tsumego-edit-submit');
 
-		// Verify the stored description was normalized (White->Black)
+		// Verify the stored description was un-swapped (Black->White) back to true-color
 		$saved = ClassRegistry::init('Tsumego')->findById($context->tsumegos[0]['id']);
-		$this->assertSame('Black to play here.', $saved['Tsumego']['description']);
+		$this->assertSame('White to play here.', $saved['Tsumego']['description']);
 	}
 
 	/**
-	 * Browser test: Admin edits description on a puzzle where colors are NOT swapped.
-	 * B-first SGF + playercolor=black -> no swap -> textarea shows original text.
+	 * Browser test: Admin edits description on a puzzle where board is NOT inverted.
+	 * B-first SGF + playercolor=black -> no swap -> textarea shows true-color text.
 	 * After editing and saving, the stored description is kept as-is.
 	 */
 	public function testDescriptionEditNoSwap(): void
@@ -901,7 +901,7 @@ class TsumegosControllerTest extends TestCaseWithAuth
 
 		$browser = Browser::instance();
 		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
-		// B-first SGF + playercolor=black -> pl=0, sP=0 -> shouldSwap=false
+		// B-first SGF + playercolor=black -> pl=0 -> shouldSwap=false
 		$browser->get($setConnectionId . '?playercolor=black');
 
 		// Click the (Edit) link to reveal the form
@@ -959,18 +959,18 @@ class TsumegosControllerTest extends TestCaseWithAuth
 	 *   White-first SGF -> firstMove stays WHITE -> player places WHITE stones visually
 	 *
 	 * The description should match the VISUAL stone color the player places.
-	 * Under normalized convention, description stores "Black to play".
-	 * The swap formula ($pl != $startingPlayer) ensures correct visual match.
+	 * Under true-color convention, description stores "White to play" for W-first SGFs.
+	 * When board is inverted (pl=1), swap makes it "Black to play" to match visual.
 	 */
 	public function testDescriptionMatchesActualFirstMoveColor(): void
 	{
 		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
 
-		// Normalized convention: "Black to play" stored for ALL puzzles (Black = solver)
+		// True-color convention: "White to play" stored for W-first SGFs
 		$context = new ContextPreparator([
 			'tsumego' => [
 				'set_order' => 1,
-				'description' => 'Black to play',
+				'description' => 'White to play',
 				'sgf' => $whiteFirstSgf,
 			],
 		]);
@@ -1008,15 +1008,15 @@ class TsumegosControllerTest extends TestCaseWithAuth
 	}
 
 	/**
-	 * OG description should swap Black/White for White-first SGFs,
-	 * since the OG image always renders actual SGF stone colors.
+	 * OG description uses true-color convention — no swap needed.
+	 * The OG image renders actual SGF colors, and descriptions match the board.
 	 */
-	public function testOgDescriptionSwapsColorForWhiteFirstSgf(): void
+	public function testOgDescriptionUsesTrueColor(): void
 	{
 		$blackFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])';
 		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
 
-		// Black-first: OG description keeps "Black" (no swap)
+		// Black-first: OG description shows true-color "Black"
 		$context = new ContextPreparator([
 			'tsumego' => ['set_order' => 1, 'description' => 'Black to capture the white group', 'sgf' => $blackFirstSgf],
 		]);
@@ -1028,9 +1028,9 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$this->assertNotEmpty($m, 'og:description should exist for Black-first SGF');
 		$this->assertStringContainsString('Black to capture the white group', $m[1]);
 
-		// White-first: OG description swaps "Black" -> "White"
+		// White-first: OG description shows true-color "White"
 		$context2 = new ContextPreparator([
-			'tsumego' => ['set_order' => 1, 'description' => 'Black to capture the white group', 'sgf' => $whiteFirstSgf],
+			'tsumego' => ['set_order' => 1, 'description' => 'White to capture the black group', 'sgf' => $whiteFirstSgf],
 		]);
 		$result2 = $this->testAction(
 			'tsumegos/play/' . $context2->tsumegos[0]['id'],

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -6,6 +6,8 @@ use Facebook\WebDriver\WebDriverWait;
 use Facebook\WebDriver\Exception\TimeoutException;
 
 App::uses('NotFoundException', 'Routing/Error');
+App::uses('User', 'Model');
+App::uses('Constants', 'Utility');
 
 class TsumegosControllerTest extends TestCaseWithAuth
 {
@@ -784,65 +786,36 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$this->assertMatchesRegularExpression('/"diff":"[a-z]+"/', $result);
 	}
 
-	public static function descriptionColorSwapProvider(): array
+	public function testDescriptionColorSwap(): void
 	{
 		$blackFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])';
 		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
 
-		return [
-			'no swap: Black visual (pl=0) + Black-first SGF, true-color matches' => [
-				"Black's stones attack White's group. black wins!",
-				$blackFirstSgf,
-				'black',
-				"Black's stones attack White's group. black wins!",
-			],
-			'swap: White visual (pl=1) + Black-first SGF, board inverted' => [
-				"Black's stones. Kill the white group near the Blackbird. Watch whitespace.",
-				$blackFirstSgf,
-				'white',
-				"White's stones. Kill the black group near the Blackbird. Watch whitespace.",
-			],
-			'no swap: Black visual (pl=0) + White-first SGF, true-color matches' => [
-				"White to play. Attack the black group.",
-				$whiteFirstSgf,
-				'black',
-				"White to play. Attack the black group.",
-			],
-			'swap: White visual (pl=1) + White-first SGF, board inverted' => [
-				"White to play. Attack the black group.",
-				$whiteFirstSgf,
-				'white',
-				"Black to play. Attack the white group.",
-			],
-		];
-	}
-
-	/**
-	 * @dataProvider descriptionColorSwapProvider
-	 */
-	public function testDescriptionColorSwap(string $description, string $sgf, string $playerColor, string $expected): void
-	{
+		// ORIGINAL preference: the player follows the SGF first move, so the board
+		// is never inverted and the description is shown exactly as stored (true-color).
 		$context = new ContextPreparator([
-			'tsumego' => [
-				'set_order' => 1,
-				'description' => $description,
-				'sgf' => $sgf,
-			]
+			'user' => ['name' => 'descColorSwapB'],
+			'tsumego' => ['set_order' => 1, 'description' => "Black's stones attack White's group.", 'sgf' => $blackFirstSgf],
 		]);
-
-		$this->testAction(
-			'tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=' . $playerColor,
-			['return' => 'view']
-		);
-
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'], ['return' => 'view']);
 		$decoded = htmlspecialchars_decode(strip_tags($this->view));
-		$this->assertStringContainsString($expected, $decoded);
+		$this->assertStringContainsString("Black's stones attack White's group.", $decoded);
+
+		$context2 = new ContextPreparator([
+			'user' => ['name' => 'descColorSwapW'],
+			'tsumego' => ['set_order' => 1, 'description' => 'White to play. Attack the black group.', 'sgf' => $whiteFirstSgf],
+		]);
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context2->tsumegos[0]['id'], ['return' => 'view']);
+		$decoded = htmlspecialchars_decode(strip_tags($this->view));
+		$this->assertStringContainsString('White to play. Attack the black group.', $decoded);
 	}
 
 	/**
-	 * Browser test: Admin edits description on a puzzle where board is inverted.
-	 * W-first SGF + playercolor=white -> board inverted -> textarea shows swapped text.
-	 * After editing and saving, the stored description is un-swapped back to true-color.
+	 * Controller test: When the edit form is shown with an inverted board it
+	 * submits color_swapped=1, so the description is swapped Black<->White
+	 * back to true-color on save.
 	 */
 	public function testDescriptionEditWithSwap(): void
 	{
@@ -851,42 +824,34 @@ class TsumegosControllerTest extends TestCaseWithAuth
 			'tsumego' => [
 				'set_order' => 1,
 				'description' => 'White to attack the black stones.',
-				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])'
-			]
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])',
+			],
+		]);
+		$tsumegoId = $context->tsumegos[0]['id'];
+
+		$this->testAction('/tsumegos/edit/' . $tsumegoId, [
+			'method' => 'post',
+			'data' => [
+				'delete' => '',
+				'description' => 'Black to play here.',
+				'color_swapped' => '1',
+				'rating' => '1500',
+				'minimum-rating' => '',
+				'maximum-rating' => '',
+				'hint' => '',
+				'author' => '',
+				'redirect' => '/',
+			],
+			'return' => 'contents',
 		]);
 
-		$browser = Browser::instance();
-		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
-		// W-first SGF + playercolor=white -> pl=1 -> shouldSwap=true
-		$browser->get($setConnectionId . '?playercolor=white');
-
-		// Click the (Edit) link to reveal the form
-		$browser->clickId('modify-description');
-
-		// Verify the textarea shows swapped text (White->Black for inverted display)
-		$textarea = $browser->find('#description');
-		$this->assertSame('Black to attack the white stones.', $textarea->getAttribute('value'));
-
-		// Verify hidden color_swapped field is 1
-		$colorSwapped = $browser->find('input[name="color_swapped"]');
-		$this->assertSame('1', $colorSwapped->getAttribute('value'));
-
-		// Edit the description to something new (still in swapped/display form)
-		$textarea->clear();
-		$textarea->sendKeys('Black to play here.');
-
-		// Submit the form
-		$browser->clickId('tsumego-edit-submit');
-
-		// Verify the stored description was un-swapped (Black->White) back to true-color
-		$saved = ClassRegistry::init('Tsumego')->findById($context->tsumegos[0]['id']);
+		$saved = ClassRegistry::init('Tsumego')->findById($tsumegoId);
 		$this->assertSame('White to play here.', $saved['Tsumego']['description']);
 	}
 
 	/**
-	 * Browser test: Admin edits description on a puzzle where board is NOT inverted.
-	 * B-first SGF + playercolor=black -> no swap -> textarea shows true-color text.
-	 * After editing and saving, the stored description is kept as-is.
+	 * Controller test: When the edit form is shown without an inverted board it
+	 * submits color_swapped=0, so the description is stored as-is (true-color).
 	 */
 	public function testDescriptionEditNoSwap(): void
 	{
@@ -895,116 +860,29 @@ class TsumegosControllerTest extends TestCaseWithAuth
 			'tsumego' => [
 				'set_order' => 1,
 				'description' => 'Black to attack the white stones.',
-				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])'
-			]
-		]);
-
-		$browser = Browser::instance();
-		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
-		// B-first SGF + playercolor=black -> pl=0 -> shouldSwap=false
-		$browser->get($setConnectionId . '?playercolor=black');
-
-		// Click the (Edit) link to reveal the form
-		$browser->clickId('modify-description');
-
-		// Verify the textarea shows original text (no swap)
-		$textarea = $browser->find('#description');
-		$this->assertSame('Black to attack the white stones.', $textarea->getAttribute('value'));
-
-		// Verify hidden color_swapped field is 0
-		$colorSwapped = $browser->find('input[name="color_swapped"]');
-		$this->assertSame('0', $colorSwapped->getAttribute('value'));
-
-		// Edit the description
-		$textarea->clear();
-		$textarea->sendKeys('Black to play first.');
-
-		// Submit the form
-		$browser->clickId('tsumego-edit-submit');
-
-		// Verify it was stored as-is (no normalization needed)
-		$saved = ClassRegistry::init('Tsumego')->findById($context->tsumegos[0]['id']);
-		$this->assertSame('Black to play first.', $saved['Tsumego']['description']);
-	}
-
-	public static function startingPlayerProvider(): array
-	{
-		return [
-			'Black first' => ['(;GM[1]FF[4]SZ[19];B[aa];W[ab])', 0],
-			'White first' => ['(;GM[1]FF[4]SZ[19];W[aa];B[ab])', 1],
-			'Black only' => ['(;GM[1]FF[4]SZ[19];B[aa])', 0],
-			'White only' => ['(;GM[1]FF[4]SZ[19];W[aa])', 1],
-		];
-	}
-
-	/**
-	 * @dataProvider startingPlayerProvider
-	 */
-	public function testGetStartingPlayer(string $sgf, int $expected): void
-	{
-		$this->assertSame($expected, TsumegosController::getStartingPlayer($sgf));
-	}
-
-	/**
-	 * Browser test: For a White-first SGF, check what color the player actually places
-	 * and whether the description matches that visual color.
-	 *
-	 * Key insight: besogoPlayerColor controls board INVERSION, not the player's stone color.
-	 * The player's visual stone color is: besogo.editor.getCurrent().nextMove()
-	 *   -1 = Black stone on screen, 1 = White stone on screen
-	 *
-	 * When besogoPlayerColor="white" (inversion active):
-	 *   White-first SGF -> firstMove inverted to BLACK -> player places BLACK stones visually
-	 * When besogoPlayerColor="black" (no inversion):
-	 *   White-first SGF -> firstMove stays WHITE -> player places WHITE stones visually
-	 *
-	 * The description should match the VISUAL stone color the player places.
-	 * Under true-color convention, description stores "White to play" for W-first SGFs.
-	 * When board is inverted (pl=1), swap makes it "Black to play" to match visual.
-	 */
-	public function testDescriptionMatchesActualFirstMoveColor(): void
-	{
-		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
-
-		// True-color convention: "White to play" stored for W-first SGFs
-		$context = new ContextPreparator([
-			'tsumego' => [
-				'set_order' => 1,
-				'description' => 'White to play',
-				'sgf' => $whiteFirstSgf,
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])',
 			],
 		]);
+		$tsumegoId = $context->tsumegos[0]['id'];
 
-		$browser = Browser::instance();
-		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
+		$this->testAction('/tsumegos/edit/' . $tsumegoId, [
+			'method' => 'post',
+			'data' => [
+				'delete' => '',
+				'description' => 'Black to play first.',
+				'color_swapped' => '0',
+				'rating' => '1500',
+				'minimum-rating' => '',
+				'maximum-rating' => '',
+				'hint' => '',
+				'author' => '',
+				'redirect' => '/',
+			],
+			'return' => 'contents',
+		]);
 
-		for ($i = 0; $i < 10; $i++)
-		{
-			$browser->get((string) $setConnectionId);
-
-			$descriptionText = $browser->find('#descriptionText')->getText();
-			$besogoColor = $browser->driver->executeScript("return besogoPlayerColor;");
-
-			// Wait for besogo to initialize
-			$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
-			$wait->until(function () use ($browser) {
-				return $browser->driver->executeScript("return typeof besogo !== 'undefined' && besogo.editor !== undefined;");
-			});
-
-			// nextMove() returns -1 (BLACK) or 1 (WHITE) -- the ACTUAL visual stone color
-			$nextMove = $browser->driver->executeScript("return besogo.editor.getCurrent().nextMove();");
-			$visualStoneColor = ($nextMove === -1) ? 'Black' : 'White';
-
-			$descriptionSaysBlack = str_contains($descriptionText, 'Black');
-			$descriptionSaysWhite = str_contains($descriptionText, 'White');
-
-			// The description color should match the visual stone color
-			$this->assertTrue(
-				($visualStoneColor === 'Black' && $descriptionSaysBlack)
-				|| ($visualStoneColor === 'White' && $descriptionSaysWhite),
-				"Iteration $i: description='$descriptionText', visual stone=$visualStoneColor, besogoPlayerColor=$besogoColor"
-			);
-		}
+		$saved = ClassRegistry::init('Tsumego')->findById($tsumegoId);
+		$this->assertSame('Black to play first.', $saved['Tsumego']['description']);
 	}
 
 	/**
@@ -1050,7 +928,7 @@ class TsumegosControllerTest extends TestCaseWithAuth
 
 	/**
 	 * Custom multiple-choice variant answers are stored in true colors. When the
-	 * board is inverted (playercolor=white), the answer text is swapped so it
+	 * board is inverted (?playercolor=white), the answer text is swapped so it
 	 * matches the stones the player actually sees.
 	 */
 	public function testMultipleChoiceVariantAnswersSwapWhenBoardInverted(): void

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -499,4 +499,261 @@ class TsumegosControllerTest extends TestCaseWithAuth
 
 		$this->assertMatchesRegularExpression('/"diff":"[a-z]+"/', $result);
 	}
+
+	public static function descriptionColorSwapProvider(): array
+	{
+		$blackFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])';
+		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
+
+		return [
+			'no swap: Black visual (pl=0) + Black-first SGF' => [
+				"Black's stones attack White's group. black wins!",
+				$blackFirstSgf,
+				'black',
+				"Black's stones attack White's group. black wins!",
+			],
+			'swap: White visual (pl=1) + Black-first SGF, preserves word boundaries' => [
+				"Black's stones. Kill the white group near the Blackbird. Watch whitespace.",
+				$blackFirstSgf,
+				'white',
+				"White's stones. Kill the black group near the Blackbird. Watch whitespace.",
+			],
+			'swap: Black visual (pl=0) + White-first SGF, normalized Black swaps to White' => [
+				"Black to play. Attack the white group.",
+				$whiteFirstSgf,
+				'black',
+				"White to play. Attack the black group.",
+			],
+			'no swap: White visual (pl=1) + White-first SGF, normalized Black stays' => [
+				"Black to play. Attack the white group.",
+				$whiteFirstSgf,
+				'white',
+				"Black to play. Attack the white group.",
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider descriptionColorSwapProvider
+	 */
+	public function testDescriptionColorSwap(string $description, string $sgf, string $playerColor, string $expected): void
+	{
+		$context = new ContextPreparator([
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => $description,
+				'sgf' => $sgf,
+			]
+		]);
+
+		$this->testAction(
+			'tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=' . $playerColor,
+			['return' => 'view']
+		);
+
+		$decoded = htmlspecialchars_decode(strip_tags($this->view));
+		$this->assertStringContainsString($expected, $decoded);
+	}
+
+	/**
+	 * Browser test: Admin edits description on a puzzle where colors are swapped.
+	 * W-first SGF + playercolor=black -> swap active -> textarea shows swapped text.
+	 * After editing and saving, the stored description is normalized back (Black = solver).
+	 */
+	public function testDescriptionEditWithSwap(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['admin' => true],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to attack the white stones.',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])'
+			]
+		]);
+
+		$browser = Browser::instance();
+		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
+		// W-first SGF + playercolor=black -> pl=0, sP=1 -> shouldSwap=true
+		$browser->get($setConnectionId . '?playercolor=black');
+
+		// Click the (Edit) link to reveal the form
+		$browser->clickId('modify-description');
+
+		// Verify the textarea shows swapped text (Black->White for display)
+		$textarea = $browser->find('#description');
+		$this->assertSame('White to attack the black stones.', $textarea->getAttribute('value'));
+
+		// Verify hidden color_swapped field is 1
+		$colorSwapped = $browser->find('input[name="color_swapped"]');
+		$this->assertSame('1', $colorSwapped->getAttribute('value'));
+
+		// Edit the description to something new (still in swapped/display form)
+		$textarea->clear();
+		$textarea->sendKeys('White to play here.');
+
+		// Submit the form
+		$browser->clickId('tsumego-edit-submit');
+
+		// Verify the stored description was normalized (White->Black)
+		$saved = ClassRegistry::init('Tsumego')->findById($context->tsumegos[0]['id']);
+		$this->assertSame('Black to play here.', $saved['Tsumego']['description']);
+	}
+
+	/**
+	 * Browser test: Admin edits description on a puzzle where colors are NOT swapped.
+	 * B-first SGF + playercolor=black -> no swap -> textarea shows original text.
+	 * After editing and saving, the stored description is kept as-is.
+	 */
+	public function testDescriptionEditNoSwap(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['admin' => true],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to attack the white stones.',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])'
+			]
+		]);
+
+		$browser = Browser::instance();
+		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
+		// B-first SGF + playercolor=black -> pl=0, sP=0 -> shouldSwap=false
+		$browser->get($setConnectionId . '?playercolor=black');
+
+		// Click the (Edit) link to reveal the form
+		$browser->clickId('modify-description');
+
+		// Verify the textarea shows original text (no swap)
+		$textarea = $browser->find('#description');
+		$this->assertSame('Black to attack the white stones.', $textarea->getAttribute('value'));
+
+		// Verify hidden color_swapped field is 0
+		$colorSwapped = $browser->find('input[name="color_swapped"]');
+		$this->assertSame('0', $colorSwapped->getAttribute('value'));
+
+		// Edit the description
+		$textarea->clear();
+		$textarea->sendKeys('Black to play first.');
+
+		// Submit the form
+		$browser->clickId('tsumego-edit-submit');
+
+		// Verify it was stored as-is (no normalization needed)
+		$saved = ClassRegistry::init('Tsumego')->findById($context->tsumegos[0]['id']);
+		$this->assertSame('Black to play first.', $saved['Tsumego']['description']);
+	}
+
+	public static function startingPlayerProvider(): array
+	{
+		return [
+			'Black first' => ['(;GM[1]FF[4]SZ[19];B[aa];W[ab])', 0],
+			'White first' => ['(;GM[1]FF[4]SZ[19];W[aa];B[ab])', 1],
+			'Black only' => ['(;GM[1]FF[4]SZ[19];B[aa])', 0],
+			'White only' => ['(;GM[1]FF[4]SZ[19];W[aa])', 1],
+		];
+	}
+
+	/**
+	 * @dataProvider startingPlayerProvider
+	 */
+	public function testGetStartingPlayer(string $sgf, int $expected): void
+	{
+		$this->assertSame($expected, TsumegosController::getStartingPlayer($sgf));
+	}
+
+	/**
+	 * Browser test: For a White-first SGF, check what color the player actually places
+	 * and whether the description matches that visual color.
+	 *
+	 * Key insight: besogoPlayerColor controls board INVERSION, not the player's stone color.
+	 * The player's visual stone color is: besogo.editor.getCurrent().nextMove()
+	 *   -1 = Black stone on screen, 1 = White stone on screen
+	 *
+	 * When besogoPlayerColor="white" (inversion active):
+	 *   White-first SGF -> firstMove inverted to BLACK -> player places BLACK stones visually
+	 * When besogoPlayerColor="black" (no inversion):
+	 *   White-first SGF -> firstMove stays WHITE -> player places WHITE stones visually
+	 *
+	 * The description should match the VISUAL stone color the player places.
+	 * Under normalized convention, description stores "Black to play".
+	 * The swap formula ($pl != $startingPlayer) ensures correct visual match.
+	 */
+	public function testDescriptionMatchesActualFirstMoveColor(): void
+	{
+		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
+
+		// Normalized convention: "Black to play" stored for ALL puzzles (Black = solver)
+		$context = new ContextPreparator([
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to play',
+				'sgf' => $whiteFirstSgf,
+			],
+		]);
+
+		$browser = Browser::instance();
+		$setConnectionId = $context->tsumegos[0]['set-connections'][0]['id'];
+
+		for ($i = 0; $i < 10; $i++)
+		{
+			$browser->get((string) $setConnectionId);
+
+			$descriptionText = $browser->find('#descriptionText')->getText();
+			$besogoColor = $browser->driver->executeScript("return besogoPlayerColor;");
+
+			// Wait for besogo to initialize
+			$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
+			$wait->until(function () use ($browser) {
+				return $browser->driver->executeScript("return typeof besogo !== 'undefined' && besogo.editor !== undefined;");
+			});
+
+			// nextMove() returns -1 (BLACK) or 1 (WHITE) -- the ACTUAL visual stone color
+			$nextMove = $browser->driver->executeScript("return besogo.editor.getCurrent().nextMove();");
+			$visualStoneColor = ($nextMove === -1) ? 'Black' : 'White';
+
+			$descriptionSaysBlack = str_contains($descriptionText, 'Black');
+			$descriptionSaysWhite = str_contains($descriptionText, 'White');
+
+			// The description color should match the visual stone color
+			$this->assertTrue(
+				($visualStoneColor === 'Black' && $descriptionSaysBlack)
+				|| ($visualStoneColor === 'White' && $descriptionSaysWhite),
+				"Iteration $i: description='$descriptionText', visual stone=$visualStoneColor, besogoPlayerColor=$besogoColor"
+			);
+		}
+	}
+
+	/**
+	 * OG description should swap Black/White for White-first SGFs,
+	 * since the OG image always renders actual SGF stone colors.
+	 */
+	public function testOgDescriptionSwapsColorForWhiteFirstSgf(): void
+	{
+		$blackFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])';
+		$whiteFirstSgf = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
+
+		// Black-first: OG description keeps "Black" (no swap)
+		$context = new ContextPreparator([
+			'tsumego' => ['set_order' => 1, 'description' => 'Black to capture the white group', 'sgf' => $blackFirstSgf],
+		]);
+		$result = $this->testAction(
+			'tsumegos/play/' . $context->tsumegos[0]['id'],
+			['return' => 'contents']
+		);
+		preg_match('/property="og:description"\s+content="([^"]*)"/', $result, $m);
+		$this->assertNotEmpty($m, 'og:description should exist for Black-first SGF');
+		$this->assertStringContainsString('Black to capture the white group', $m[1]);
+
+		// White-first: OG description swaps "Black" -> "White"
+		$context2 = new ContextPreparator([
+			'tsumego' => ['set_order' => 1, 'description' => 'Black to capture the white group', 'sgf' => $whiteFirstSgf],
+		]);
+		$result2 = $this->testAction(
+			'tsumegos/play/' . $context2->tsumegos[0]['id'],
+			['return' => 'contents']
+		);
+		preg_match('/property="og:description"\s+content="([^"]*)"/', $result2, $m2);
+		$this->assertNotEmpty($m2, 'og:description should exist for White-first SGF');
+		$this->assertStringContainsString('White to capture the black group', $m2[1]);
+	}
 }

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -1040,4 +1040,118 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$this->assertNotEmpty($m2, 'og:description should exist for White-first SGF');
 		$this->assertStringContainsString('White to capture the black group', $m2[1]);
 	}
+
+	private function createTsumegoVariant(int $tsumegoId, array $variantData): void
+	{
+		$variant = ['TsumegoVariant' => array_merge(['tsumego_id' => $tsumegoId], $variantData)];
+		ClassRegistry::init('TsumegoVariant')->create($variant);
+		ClassRegistry::init('TsumegoVariant')->save($variant);
+	}
+
+	/**
+	 * Custom multiple-choice variant answers are stored in true colors. When the
+	 * board is inverted (playercolor=white), the answer text is swapped so it
+	 * matches the stones the player actually sees.
+	 */
+	public function testMultipleChoiceVariantAnswersSwapWhenBoardInverted(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['mode' => Constants::$LEVEL_MODE],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to play. What is the result?',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])',
+			],
+		]);
+		$this->createTsumegoVariant($context->tsumegos[0]['id'], [
+			'type' => 'multiple_choice',
+			'answer1' => 'White is dead',
+			'answer2' => 'Ko',
+			'answer3' => 'Seki in sente',
+			'answer4' => 'Seki in gote',
+			'numAnswer' => '3',
+		]);
+
+		// No inversion: answers keep their true colors.
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'], ['return' => 'view']);
+		$this->assertStringContainsString('"White is dead"', $this->view);
+
+		// Inverted board: the answer text is swapped to match the visual stones.
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=white', ['return' => 'view']);
+		$this->assertStringContainsString('"Black is dead"', $this->view);
+		$this->assertStringNotContainsString('"White is dead"', $this->view);
+	}
+
+	/**
+	 * Score-estimating summary labels are stored in true colors. When the board
+	 * is inverted, the "Black/White captures" labels swap while the numeric
+	 * values stay in place.
+	 */
+	public function testScoreEstimatingLabelsSwapWhenBoardInverted(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['mode' => Constants::$LEVEL_MODE],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Who wins?',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])',
+			],
+		]);
+		$this->createTsumegoVariant($context->tsumegos[0]['id'], [
+			'type' => 'score_estimating',
+			'answer1' => '6.5',
+			'answer2' => '3',
+			'answer3' => '6',
+			'numAnswer' => '0',
+		]);
+
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'], ['return' => 'view']);
+		$this->assertStringContainsString('Black captures: 3', $this->view);
+		$this->assertStringContainsString('White captures: 6', $this->view);
+
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=white', ['return' => 'view']);
+		$this->assertStringContainsString('White captures: 3', $this->view);
+		$this->assertStringContainsString('Black captures: 6', $this->view);
+	}
+
+	/**
+	 * Browser test: clicking the color-orientation button inverts the board and
+	 * swaps the multiple-choice answer text so it matches the visual stones.
+	 */
+	public function testOrientationButtonSwapsVariantAnswers(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['admin' => true],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to play. What is the result?',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19]AB[cc]AW[dd];B[aa];W[ab];B[ba]C[+])',
+			],
+		]);
+		$this->createTsumegoVariant($context->tsumegos[0]['id'], [
+			'type' => 'multiple_choice',
+			'answer1' => 'White is dead',
+			'answer2' => 'Ko',
+			'answer3' => 'Seki in sente',
+			'answer4' => 'Seki in gote',
+			'numAnswer' => '3',
+		]);
+
+		$browser = Browser::instance();
+		$browser->get((string) $context->tsumegos[0]['set-connections'][0]['id']);
+
+		$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
+		$wait->until(function () use ($browser) {
+			return $browser->driver->executeScript(
+				"return typeof besogo !== 'undefined' && document.getElementById('besogo-multipleChoice1') !== null;"
+			);
+		});
+
+		$this->assertSame('White is dead', $browser->find('#besogo-multipleChoice1')->getAttribute('value'));
+
+		$browser->driver->executeScript("document.getElementById('colorOrientation').click();");
+
+		$this->assertSame('Black is dead', $browser->find('#besogo-multipleChoice1')->getAttribute('value'));
+		$this->assertSame('White to play. What is the result?', $browser->find('#descriptionText')->getText());
+	}
 }

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -756,4 +756,118 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$this->assertNotEmpty($m2, 'og:description should exist for White-first SGF');
 		$this->assertStringContainsString('White to capture the black group', $m2[1]);
 	}
+
+	private function createTsumegoVariant(int $tsumegoId, array $variantData): void
+	{
+		$variant = ['TsumegoVariant' => array_merge(['tsumego_id' => $tsumegoId], $variantData)];
+		ClassRegistry::init('TsumegoVariant')->create($variant);
+		ClassRegistry::init('TsumegoVariant')->save($variant);
+	}
+
+	/**
+	 * Custom multiple-choice variant answers are stored in true colors. When the
+	 * board is inverted (playercolor=white), the answer text is swapped so it
+	 * matches the stones the player actually sees.
+	 */
+	public function testMultipleChoiceVariantAnswersSwapWhenBoardInverted(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['mode' => Constants::$LEVEL_MODE],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to play. What is the result?',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])',
+			],
+		]);
+		$this->createTsumegoVariant($context->tsumegos[0]['id'], [
+			'type' => 'multiple_choice',
+			'answer1' => 'White is dead',
+			'answer2' => 'Ko',
+			'answer3' => 'Seki in sente',
+			'answer4' => 'Seki in gote',
+			'numAnswer' => '3',
+		]);
+
+		// No inversion: answers keep their true colors.
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'], ['return' => 'view']);
+		$this->assertStringContainsString('"White is dead"', $this->view);
+
+		// Inverted board: the answer text is swapped to match the visual stones.
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=white', ['return' => 'view']);
+		$this->assertStringContainsString('"Black is dead"', $this->view);
+		$this->assertStringNotContainsString('"White is dead"', $this->view);
+	}
+
+	/**
+	 * Score-estimating summary labels are stored in true colors. When the board
+	 * is inverted, the "Black/White captures" labels swap while the numeric
+	 * values stay in place.
+	 */
+	public function testScoreEstimatingLabelsSwapWhenBoardInverted(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['mode' => Constants::$LEVEL_MODE],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Who wins?',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])',
+			],
+		]);
+		$this->createTsumegoVariant($context->tsumegos[0]['id'], [
+			'type' => 'score_estimating',
+			'answer1' => '6.5',
+			'answer2' => '3',
+			'answer3' => '6',
+			'numAnswer' => '0',
+		]);
+
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'], ['return' => 'view']);
+		$this->assertStringContainsString('Black captures: 3', $this->view);
+		$this->assertStringContainsString('White captures: 6', $this->view);
+
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=white', ['return' => 'view']);
+		$this->assertStringContainsString('White captures: 3', $this->view);
+		$this->assertStringContainsString('Black captures: 6', $this->view);
+	}
+
+	/**
+	 * Browser test: clicking the color-orientation button inverts the board and
+	 * swaps the multiple-choice answer text so it matches the visual stones.
+	 */
+	public function testOrientationButtonSwapsVariantAnswers(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['admin' => true],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to play. What is the result?',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19]AB[cc]AW[dd];B[aa];W[ab];B[ba]C[+])',
+			],
+		]);
+		$this->createTsumegoVariant($context->tsumegos[0]['id'], [
+			'type' => 'multiple_choice',
+			'answer1' => 'White is dead',
+			'answer2' => 'Ko',
+			'answer3' => 'Seki in sente',
+			'answer4' => 'Seki in gote',
+			'numAnswer' => '3',
+		]);
+
+		$browser = Browser::instance();
+		$browser->get((string) $context->tsumegos[0]['set-connections'][0]['id']);
+
+		$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
+		$wait->until(function () use ($browser) {
+			return $browser->driver->executeScript(
+				"return typeof besogo !== 'undefined' && document.getElementById('besogo-multipleChoice1') !== null;"
+			);
+		});
+
+		$this->assertSame('White is dead', $browser->find('#besogo-multipleChoice1')->getAttribute('value'));
+
+		$browser->driver->executeScript("document.getElementById('colorOrientation').click();");
+
+		$this->assertSame('Black is dead', $browser->find('#besogo-multipleChoice1')->getAttribute('value'));
+		$this->assertSame('White to play. What is the result?', $browser->find('#descriptionText')->getText());
+	}
 }

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -1174,16 +1174,16 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
 		$wait->until(function () use ($browser) {
 			return $browser->driver->executeScript(
-				"return typeof besogo !== 'undefined' && document.getElementById('besogo-se-winner-black') !== null;"
+				"return typeof besogo !== 'undefined' && document.getElementById('besogo-se-black') !== null;"
 			);
 		});
 
-		$this->assertSame('Black wins', $browser->find('#besogo-se-winner-black')->getAttribute('value'));
+		$this->assertSame('Black wins', $browser->find('#besogo-se-black')->getAttribute('value'));
 
 		$browser->driver->executeScript("document.getElementById('colorOrientation').click();");
 
-		$this->assertSame('White wins', $browser->find('#besogo-se-winner-black')->getAttribute('value'));
-		$this->assertSame('Black wins', $browser->find('#besogo-se-winner-white')->getAttribute('value'));
+		$this->assertSame('White wins', $browser->find('#besogo-se-black')->getAttribute('value'));
+		$this->assertSame('Black wins', $browser->find('#besogo-se-white')->getAttribute('value'));
 	}
 
 	/**

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -1174,16 +1174,16 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
 		$wait->until(function () use ($browser) {
 			return $browser->driver->executeScript(
-				"return typeof besogo !== 'undefined' && document.getElementById('besogo-score-wins-a') !== null;"
+				"return typeof besogo !== 'undefined' && document.getElementById('besogo-se-winner-black') !== null;"
 			);
 		});
 
-		$this->assertSame('Black wins', $browser->find('#besogo-score-wins-a')->getAttribute('value'));
+		$this->assertSame('Black wins', $browser->find('#besogo-se-winner-black')->getAttribute('value'));
 
 		$browser->driver->executeScript("document.getElementById('colorOrientation').click();");
 
-		$this->assertSame('White wins', $browser->find('#besogo-score-wins-a')->getAttribute('value'));
-		$this->assertSame('Black wins', $browser->find('#besogo-score-wins-b')->getAttribute('value'));
+		$this->assertSame('White wins', $browser->find('#besogo-se-winner-black')->getAttribute('value'));
+		$this->assertSame('Black wins', $browser->find('#besogo-se-winner-white')->getAttribute('value'));
 	}
 
 	/**

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -1143,4 +1143,122 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'], ['return' => 'view']);
 		$this->assertStringContainsString('Black to play. Find the way to kill the white group.', $this->view);
 	}
+
+	/**
+	 * Browser test: the orientation button swaps the score-estimating "Black wins" /
+	 * "White wins" buttons so they match the inverted board.
+	 */
+	public function testOrientationButtonSwapsScoreButtons(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['admin' => true],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Who wins?',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])',
+				'variants' => [[
+					'type' => 'score_estimating',
+					'answer1' => '6.5',
+					'answer2' => '3',
+					'answer3' => '6',
+					'numAnswer' => '0',
+				]],
+			],
+		]);
+
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+
+		$browser = Browser::instance();
+		$browser->get((string) $context->tsumegos[0]['set-connections'][0]['id']);
+
+		$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
+		$wait->until(function () use ($browser) {
+			return $browser->driver->executeScript(
+				"return typeof besogo !== 'undefined' && document.getElementById('besogo-score-wins-a') !== null;"
+			);
+		});
+
+		$this->assertSame('Black wins', $browser->find('#besogo-score-wins-a')->getAttribute('value'));
+
+		$browser->driver->executeScript("document.getElementById('colorOrientation').click();");
+
+		$this->assertSame('White wins', $browser->find('#besogo-score-wins-a')->getAttribute('value'));
+		$this->assertSame('Black wins', $browser->find('#besogo-score-wins-b')->getAttribute('value'));
+	}
+
+	/**
+	 * Browser test: the orientation button swaps the semeai "Black is dead" /
+	 * "White is dead" buttons so they match the inverted board.
+	 */
+	public function testOrientationButtonSwapsSemeaiButtons(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['admin' => true],
+			'tsumego' => [
+				'set_order' => 1,
+				'semeai_type' => 1,
+				'min_lib' => 0,
+				'max_lib' => 2,
+				'liberty_count' => 6,
+				'variance' => 2,
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19]AW[hm][im][gn][jn][go][jo][gp][jp][eq][gq][jq][fr][jr][gs][js]AB[jm][km][in][ln][io][lo][ip][lp];B[aa];W[ab];B[ba]C[+])',
+			],
+		]);
+
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+
+		$browser = Browser::instance();
+		$browser->get((string) $context->tsumegos[0]['set-connections'][0]['id']);
+
+		$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
+		$wait->until(function () use ($browser) {
+			return $browser->driver->executeScript(
+				"return typeof besogo !== 'undefined' && document.getElementById('besogo-multipleChoice1') !== null;"
+			);
+		});
+
+		$button1 = $browser->find('#besogo-multipleChoice1');
+		$button2 = $browser->find('#besogo-multipleChoice2');
+		$this->assertSame('Black is dead', $button1->getAttribute('value'));
+		$this->assertSame('White is dead', $button2->getAttribute('value'));
+
+		$browser->driver->executeScript("document.getElementById('colorOrientation').click();");
+
+		$this->assertSame('White is dead', $button1->getAttribute('value'));
+		$this->assertSame('Black is dead', $button2->getAttribute('value'));
+	}
+
+	/**
+	 * Browser test: the orientation button swaps the SGF comment text so it matches
+	 * the inverted board.
+	 */
+	public function testOrientationButtonSwapsSgfComment(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['admin' => true],
+			'tsumego' => [
+				'set_order' => 1,
+				'description' => 'Black to play.',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19]C[Black to play. Save the black group.];B[aa];W[ab];B[ba]C[+])',
+			],
+		]);
+
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+
+		$browser = Browser::instance();
+		$browser->get((string) $context->tsumegos[0]['set-connections'][0]['id']);
+
+		$wait = new \Facebook\WebDriver\WebDriverWait($browser->driver, 10);
+		$wait->until(function () use ($browser) {
+			return $browser->driver->executeScript(
+				"return typeof besogo !== 'undefined' && document.getElementById('theComment') !== null;"
+			);
+		});
+
+		$comment = $browser->find('#theComment');
+		$this->assertStringContainsString('Black to play', $comment->getText());
+
+		$browser->driver->executeScript("document.getElementById('colorOrientation').click();");
+		$this->assertStringContainsString('White to play', $comment->getText());
+	}
 }

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -1025,4 +1025,122 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$this->assertSame('Black is dead', $browser->find('#besogo-multipleChoice1')->getAttribute('value'));
 		$this->assertSame('White to play. What is the result?', $browser->find('#descriptionText')->getText());
 	}
+
+	/**
+	 * When the player's color opposes the SGF's first move the board is inverted and
+	 * the description swaps Black<->White so the player sees their own color as the
+	 * side to move. (?playercolor sets up the scenario.)
+	 */
+	public function testDescriptionSwapsWhenPlayerColorOpposesFirstMove(): void
+	{
+		$blackFirst = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])';
+		$whiteFirst = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
+
+		$context = new ContextPreparator([
+			'user' => ['name' => 'descOpposeB'],
+			'tsumego' => ['set_order' => 1, 'description' => 'Black to play.', 'sgf' => $blackFirst],
+		]);
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=white', ['return' => 'view']);
+		$this->assertStringContainsString('White to play.', $this->view);
+		$this->assertStringNotContainsString('Black to play.', $this->view);
+
+		$context2 = new ContextPreparator([
+			'user' => ['name' => 'descOpposeW'],
+			'tsumego' => ['set_order' => 1, 'description' => 'White to play.', 'sgf' => $whiteFirst],
+		]);
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context2->tsumegos[0]['id'] . '?playercolor=black', ['return' => 'view']);
+		$this->assertStringContainsString('Black to play.', $this->view);
+	}
+
+	/**
+	 * When the player's color matches the SGF's first move the board is not inverted
+	 * and the description is shown exactly as stored. (?playercolor sets up the scenario.)
+	 */
+	public function testDescriptionDoesNotSwapWhenPlayerColorMatchesFirstMove(): void
+	{
+		$blackFirst = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])';
+		$whiteFirst = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];W[aa];B[ab];W[ba]C[+])';
+
+		$context = new ContextPreparator([
+			'user' => ['name' => 'descMatchB'],
+			'tsumego' => ['set_order' => 1, 'description' => 'Black to play.', 'sgf' => $blackFirst],
+		]);
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=black', ['return' => 'view']);
+		$this->assertStringContainsString('Black to play.', $this->view);
+
+		$context2 = new ContextPreparator([
+			'user' => ['name' => 'descMatchW'],
+			'tsumego' => ['set_order' => 1, 'description' => 'White to play.', 'sgf' => $whiteFirst],
+		]);
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context2->tsumegos[0]['id'] . '?playercolor=white', ['return' => 'view']);
+		$this->assertStringContainsString('White to play.', $this->view);
+	}
+
+	/**
+	 * When the board is inverted, every color word in a description swaps, so a
+	 * description that names both colours stays internally consistent.
+	 */
+	public function testDescriptionSwapsAllColorWords(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['name' => 'descAllWords'],
+			'tsumego' => ['set_order' => 1, 'description' => 'Black to play. Find the way to kill the white group.', 'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])'],
+		]);
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=white', ['return' => 'view']);
+		$this->assertStringContainsString('White to play. Find the way to kill the black group.', $this->view);
+	}
+
+	/**
+	 * Color swaps match whole words only, so a colour word that is part of a larger
+	 * word (like "Blackbird") is left untouched.
+	 */
+	public function testDescriptionSwapRespectsWordBoundaries(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['name' => 'descBoundary'],
+			'tsumego' => ['set_order' => 1, 'description' => 'Black to play. The Blackbird group is white.', 'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])'],
+		]);
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=white', ['return' => 'view']);
+		$this->assertStringContainsString('White to play. The Blackbird group is black.', $this->view);
+	}
+
+	/**
+	 * Color swaps preserve the original casing of each word.
+	 */
+	public function testDescriptionSwapPreservesCase(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['name' => 'descCase'],
+			'tsumego' => ['set_order' => 1, 'description' => 'black stones attack White stones.', 'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])'],
+		]);
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'] . '?playercolor=white', ['return' => 'view']);
+		$this->assertStringContainsString('white stones attack Black stones.', $this->view);
+	}
+
+	/**
+	 * A White-first problem in a collection that forces the player to black (small
+	 * board) inverts the board and swaps the description automatically, without any
+	 * URL override. This is the reported "Problems from Professional Games" case.
+	 */
+	public function testForcedBlackWhiteFirstSwapsDescription(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['name' => 'descForcedBlack'],
+			'tsumego' => [
+				'sets' => [['name' => '9x9 Test Set', 'num' => 1]],
+				'description' => 'White to play. Find the way to kill the black group.',
+				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[9];W[aa];B[ab];W[ba]C[+])',
+			],
+		]);
+		Auth::saveUserField('pref_player_color', User::PREF_PLAYER_COLOR_ORIGINAL);
+		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'], ['return' => 'view']);
+		$this->assertStringContainsString('Black to play. Find the way to kill the white group.', $this->view);
+	}
 }

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -919,13 +919,6 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$this->assertStringContainsString('White to capture the black group', $m2[1]);
 	}
 
-	private function createTsumegoVariant(int $tsumegoId, array $variantData): void
-	{
-		$variant = ['TsumegoVariant' => array_merge(['tsumego_id' => $tsumegoId], $variantData)];
-		ClassRegistry::init('TsumegoVariant')->create($variant);
-		ClassRegistry::init('TsumegoVariant')->save($variant);
-	}
-
 	/**
 	 * Custom multiple-choice variant answers are stored in true colors. When the
 	 * board is inverted (?playercolor=white), the answer text is swapped so it
@@ -939,15 +932,15 @@ class TsumegosControllerTest extends TestCaseWithAuth
 				'set_order' => 1,
 				'description' => 'Black to play. What is the result?',
 				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])',
+				'variants' => [[
+					'type' => 'multiple_choice',
+					'answer1' => 'White is dead',
+					'answer2' => 'Ko',
+					'answer3' => 'Seki in sente',
+					'answer4' => 'Seki in gote',
+					'numAnswer' => '3',
+				]],
 			],
-		]);
-		$this->createTsumegoVariant($context->tsumegos[0]['id'], [
-			'type' => 'multiple_choice',
-			'answer1' => 'White is dead',
-			'answer2' => 'Ko',
-			'answer3' => 'Seki in sente',
-			'answer4' => 'Seki in gote',
-			'numAnswer' => '3',
 		]);
 
 		// No inversion: answers keep their true colors.
@@ -973,14 +966,14 @@ class TsumegosControllerTest extends TestCaseWithAuth
 				'set_order' => 1,
 				'description' => 'Who wins?',
 				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19];B[aa];W[ab];B[ba]C[+])',
+				'variants' => [[
+					'type' => 'score_estimating',
+					'answer1' => '6.5',
+					'answer2' => '3',
+					'answer3' => '6',
+					'numAnswer' => '0',
+				]],
 			],
-		]);
-		$this->createTsumegoVariant($context->tsumegos[0]['id'], [
-			'type' => 'score_estimating',
-			'answer1' => '6.5',
-			'answer2' => '3',
-			'answer3' => '6',
-			'numAnswer' => '0',
 		]);
 
 		$this->testAction('tsumegos/play/' . $context->tsumegos[0]['id'], ['return' => 'view']);
@@ -1004,15 +997,15 @@ class TsumegosControllerTest extends TestCaseWithAuth
 				'set_order' => 1,
 				'description' => 'Black to play. What is the result?',
 				'sgf' => '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19]AB[cc]AW[dd];B[aa];W[ab];B[ba]C[+])',
+				'variants' => [[
+					'type' => 'multiple_choice',
+					'answer1' => 'White is dead',
+					'answer2' => 'Ko',
+					'answer3' => 'Seki in sente',
+					'answer4' => 'Seki in gote',
+					'numAnswer' => '3',
+				]],
 			],
-		]);
-		$this->createTsumegoVariant($context->tsumegos[0]['id'], [
-			'type' => 'multiple_choice',
-			'answer1' => 'White is dead',
-			'answer2' => 'Ko',
-			'answer3' => 'Seki in sente',
-			'answer4' => 'Seki in gote',
-			'numAnswer' => '3',
 		]);
 
 		$browser = Browser::instance();

--- a/tests/TestCase/Utility/SgfParserTest.php
+++ b/tests/TestCase/Utility/SgfParserTest.php
@@ -89,4 +89,21 @@ class SgfParserTest extends CakeTestCase
 		$valid = "(;FF[4]GM[1]CA[UTF-8]AP[besogo:0.0.2-alpha]SZ[19]ST[2]\nRU[Japanese]KM[6.50]\nAB[ac][ad]AW[ab][af](;B[ae]\nC[+[b\\] can play C16 for seki]);W[ce])";
 		$this->assertNull(SgfParser::validate($valid));
 	}
+
+	public function testValidateGameDefaultsToGoWhenMissing(): void
+	{
+		// GM is omitted -> defaults to Go (1), so it must be accepted.
+		$valid = '(;FF[4]SZ[19];B[aa];W[ab])';
+		$this->assertNull(SgfParser::validateGame($valid));
+	}
+
+	public function testValidateGameAcceptsExplicitGo(): void
+	{
+		$this->assertNull(SgfParser::validateGame('(;GM[1]FF[4]SZ[19];B[aa])'));
+	}
+
+	public function testValidateGameRejectsNonGoGame(): void
+	{
+		$this->assertNotNull(SgfParser::validateGame('(;GM[2]FF[4]SZ[19];B[aa])'));
+	}
 }

--- a/tests/TestCase/Utility/SgfParserTest.php
+++ b/tests/TestCase/Utility/SgfParserTest.php
@@ -46,4 +46,47 @@ class SgfParserTest extends CakeTestCase
 		$this->assertSame('W', SgfParser::firstMoveColor('(;GM[1]SZ[19];W[aa];B[bb])'));
 		$this->assertSame('N', SgfParser::firstMoveColor('(;GM[1]SZ[19]AB[aa])'));
 	}
+
+	public function testValidateAcceptsWellFormedSgf(): void
+	{
+		$valid = "(;GM[1]FF[4]CA[UTF-8]AP[CGoban:3]ST[2]SZ[19]KM[0.00]\nAB[jm][km]AW[hm][im];B[aa];W[ab])";
+		$this->assertNull(SgfParser::validate($valid));
+	}
+
+	public function testValidateAcceptsSetupAndMoveInDifferentNodes(): void
+	{
+		$valid = '(;GM[1]SZ[19];AB[cc];B[aa])';
+		$this->assertNull(SgfParser::validate($valid));
+	}
+
+	public function testValidateRejectsMoveNodeNotPrefixedBySemicolon(): void
+	{
+		// "B[aa]" is glued to the setup node without a ';', so it is not a real move node.
+		$malformed = '(;GM[1]FF[4]CA[UTF-8]ST[2]SZ[19]AW[hm][im]AB[jm][km]B[aa];W[ab];B[ba]C[+])';
+		$this->assertNotNull(SgfParser::validate($malformed));
+	}
+
+	public function testValidateRejectsSetupAndMoveInSameNode(): void
+	{
+		$malformed = '(;GM[1]SZ[19]AB[cc]B[aa])';
+		$this->assertNotNull(SgfParser::validate($malformed));
+	}
+
+	public function testValidateRejectsUnbalancedBrackets(): void
+	{
+		$this->assertNotNull(SgfParser::validate('(;GM[1]SZ[19];B[aa)'));
+	}
+
+	public function testValidateRejectsBadPrefix(): void
+	{
+		$this->assertNotNull(SgfParser::validate('GM[1]SZ[19];B[aa]'));
+	}
+
+	public function testValidateAllowsEscapedBracketsInComment(): void
+	{
+		// A "\[" / "\]" inside a comment value must be treated as literal, not
+		// as an opening/closing bracket (this is the real SGF from the DB).
+		$valid = "(;FF[4]GM[1]CA[UTF-8]AP[besogo:0.0.2-alpha]SZ[19]ST[2]\nRU[Japanese]KM[6.50]\nAB[ac][ad]AW[ab][af](;B[ae]\nC[+[b\\] can play C16 for seki]);W[ce])";
+		$this->assertNull(SgfParser::validate($valid));
+	}
 }

--- a/webroot/besogo/js/besogo.js
+++ b/webroot/besogo/js/besogo.js
@@ -14,6 +14,16 @@
   besogo.boardCanvasSvg = null;
   besogo.intuitionActive = false;
   besogo.playerColor = "black";
+  // Shared helper: convert true-color text (Black/White) to the player's view by
+  // swapping the color words. Used when the board is color-inverted.
+  besogo.swapColorWords = function (text) {
+    return String(text).replace(/\b(Black|black|White|white)\b/g, function (m) {
+      return { Black: "White", black: "white", White: "Black", white: "black" }[m];
+    });
+  };
+  // Whether the board is currently color-inverted (true-color = stored values).
+  // Initialised from the server's swapColors and toggled by the orientation button.
+  besogo.boardInverted = false;
   besogo.soundsEnabled = false;
   besogo.controlButtonLock = true;
   besogo.theme = "";
@@ -322,6 +332,7 @@
     options.tool = options.tsumegoPlayTool || "auto";
     besogo.playerColor = options.playerColor;
     besogo.swapColors = !!options.swapColors;
+    besogo.boardInverted = besogo.swapColors;
     if (options.tsumegoPlayTool)
       options.tsumegoPlayTool = options.tsumegoPlayTool || "auto";
     if (options.panels === "") options.panels = [];

--- a/webroot/besogo/js/toolPanel.js
+++ b/webroot/besogo/js/toolPanel.js
@@ -704,12 +704,31 @@ besogo.makeToolPanel = function (container, editor) {
       function () {
         let transformation = besogo.makeTransformation();
         transformation.invertColors = true;
-        let descriptionText = $("#descriptionText").text();
-        if (descriptionText.includes("Black"))
-          descriptionText = descriptionText.replaceAll("Black", "White");
-        else if (descriptionText.includes("White"))
-          descriptionText = descriptionText.replaceAll("White", "Black");
-        $("#descriptionText").text(descriptionText);
+        let swapColorWords = function (text) {
+          return text.replace(/\b(Black|black|White|white)\b/g, function (m) {
+            return { Black: "White", black: "white", White: "Black", white: "black" }[m];
+          });
+        };
+        $("#descriptionText").text(swapColorWords($("#descriptionText").text()));
+        if (besogo.multipleChoiceCustom === "multiple_choice") {
+          // Custom multiple-choice answers are stored in true colors; match the inverted board.
+          ["besogo-multipleChoice1", "besogo-multipleChoice2", "besogo-multipleChoice3", "besogo-multipleChoice4"].forEach(function (id) {
+            let el = $("#" + id);
+            if (el.length) el.val(swapColorWords(el.val()));
+          });
+        } else if (besogo.multipleChoiceCustom === "score_estimating") {
+          // Score-estimating result buttons and summary labels.
+          ["besogo-se-black", "besogo-se-white"].forEach(function (id) {
+            let el = $("#" + id);
+            if (el.length) el.val(swapColorWords(el.val()));
+          });
+          ["submitScoreEstimatingBlackWins", "submitScoreEstimatingWhiteWins"].forEach(function (id) {
+            let el = $("#" + id);
+            if (el.length) el.text(swapColorWords(el.text()));
+          });
+          let scoreLabels = $("#scoreEstimatingLabels");
+          if (scoreLabels.length) scoreLabels.text(swapColorWords(scoreLabels.text()));
+        }
         besogo.editor.applyTransformation(transformation);
       }
     );

--- a/webroot/besogo/js/toolPanel.js
+++ b/webroot/besogo/js/toolPanel.js
@@ -706,12 +706,31 @@ besogo.makeToolPanel = function (container, editor) {
       function () {
         let transformation = besogo.makeTransformation();
         transformation.invertColors = true;
-        let descriptionText = $("#descriptionText").text();
-        if (descriptionText.includes("Black"))
-          descriptionText = descriptionText.replaceAll("Black", "White");
-        else if (descriptionText.includes("White"))
-          descriptionText = descriptionText.replaceAll("White", "Black");
-        $("#descriptionText").text(descriptionText);
+        let swapColorWords = function (text) {
+          return text.replace(/\b(Black|black|White|white)\b/g, function (m) {
+            return { Black: "White", black: "white", White: "Black", white: "black" }[m];
+          });
+        };
+        $("#descriptionText").text(swapColorWords($("#descriptionText").text()));
+        if (besogo.multipleChoiceCustom === "multiple_choice") {
+          // Custom multiple-choice answers are stored in true colors; match the inverted board.
+          ["besogo-multipleChoice1", "besogo-multipleChoice2", "besogo-multipleChoice3", "besogo-multipleChoice4"].forEach(function (id) {
+            let el = $("#" + id);
+            if (el.length) el.val(swapColorWords(el.val()));
+          });
+        } else if (besogo.multipleChoiceCustom === "score_estimating") {
+          // Score-estimating result buttons and summary labels.
+          ["besogo-se-black", "besogo-se-white"].forEach(function (id) {
+            let el = $("#" + id);
+            if (el.length) el.val(swapColorWords(el.val()));
+          });
+          ["submitScoreEstimatingBlackWins", "submitScoreEstimatingWhiteWins"].forEach(function (id) {
+            let el = $("#" + id);
+            if (el.length) el.text(swapColorWords(el.text()));
+          });
+          let scoreLabels = $("#scoreEstimatingLabels");
+          if (scoreLabels.length) scoreLabels.text(swapColorWords(scoreLabels.text()));
+        }
         besogo.editor.applyTransformation(transformation);
       }
     );

--- a/webroot/besogo/js/toolPanel.js
+++ b/webroot/besogo/js/toolPanel.js
@@ -617,21 +617,21 @@ besogo.makeToolPanel = function (container, editor) {
       if (setID != 262)
       {
         makeButtonText(
-          "Black wins",
+          besogo.boardInverted ? besogo.swapColorWords("Black wins") : "Black wins",
           "",
           function () {
             displayScoreEstimatingResult("b");
           },
-          "besogo-se-black"
+          "besogo-score-wins-a"
         );
 
         makeButtonText(
-          "White wins",
+          besogo.boardInverted ? besogo.swapColorWords("White wins") : "White wins",
           "",
           function () {
             displayScoreEstimatingResult("w");
           },
-          "besogo-se-white"
+          "besogo-score-wins-b"
         );
         makeButtonText(
           "-",
@@ -661,7 +661,7 @@ besogo.makeToolPanel = function (container, editor) {
       makeHyperlinkText("Back","previous problem", previousButtonLink, prevButtonId);
 
       makeButtonText(
-        "Black is dead",
+        besogo.boardInverted ? besogo.swapColorWords("Black is dead") : "Black is dead",
         "",
         function () {
           displayMultipleChoiceResult(1);
@@ -670,7 +670,7 @@ besogo.makeToolPanel = function (container, editor) {
       );
 
       makeButtonText(
-        "White is dead",
+        besogo.boardInverted ? besogo.swapColorWords("White is dead") : "White is dead",
         "",
         function () {
           displayMultipleChoiceResult(2);
@@ -704,33 +704,27 @@ besogo.makeToolPanel = function (container, editor) {
       "change the color of your stones",
       "colorOrientation",
       function () {
+        besogo.boardInverted = !besogo.boardInverted;
+        let swapColorWords = besogo.swapColorWords;
         let transformation = besogo.makeTransformation();
         transformation.invertColors = true;
-        let swapColorWords = function (text) {
-          return text.replace(/\b(Black|black|White|white)\b/g, function (m) {
-            return { Black: "White", black: "white", White: "Black", white: "black" }[m];
-          });
-        };
-        $("#descriptionText").text(swapColorWords($("#descriptionText").text()));
-        if (besogo.multipleChoiceCustom === "multiple_choice") {
-          // Custom multiple-choice answers are stored in true colors; match the inverted board.
-          ["besogo-multipleChoice1", "besogo-multipleChoice2", "besogo-multipleChoice3", "besogo-multipleChoice4"].forEach(function (id) {
-            let el = $("#" + id);
-            if (el.length) el.val(swapColorWords(el.val()));
-          });
-        } else if (besogo.multipleChoiceCustom === "score_estimating") {
-          // Score-estimating result buttons and summary labels.
-          ["besogo-se-black", "besogo-se-white"].forEach(function (id) {
-            let el = $("#" + id);
-            if (el.length) el.val(swapColorWords(el.val()));
-          });
-          ["submitScoreEstimatingBlackWins", "submitScoreEstimatingWhiteWins"].forEach(function (id) {
-            let el = $("#" + id);
-            if (el.length) el.text(swapColorWords(el.text()));
-          });
-          let scoreLabels = $("#scoreEstimatingLabels");
-          if (scoreLabels.length) scoreLabels.text(swapColorWords(scoreLabels.text()));
-        }
+        // Any true-color text shown to the player must follow the board's colors.
+        let desc = $("#descriptionText");
+        if (desc.length) desc.text(swapColorWords(desc.text()));
+        let theComment = $("#theComment");
+        if (theComment.length) theComment.text(swapColorWords(theComment.text()));
+        // Multiple-choice answers (custom multiple-choice and semeai share these ids).
+        ["besogo-multipleChoice1", "besogo-multipleChoice2", "besogo-multipleChoice3", "besogo-multipleChoice4"].forEach(function (id) {
+          let el = $("#" + id);
+          if (el.length) el.val(swapColorWords(el.val()));
+        });
+        // Score-estimating result buttons and summary labels.
+        ["besogo-score-wins-a", "besogo-score-wins-b"].forEach(function (id) {
+          let el = $("#" + id);
+          if (el.length) el.val(swapColorWords(el.val()));
+        });
+        let scoreLabels = $("#scoreEstimatingLabels");
+        if (scoreLabels.length) scoreLabels.text(swapColorWords(scoreLabels.text()));
         besogo.editor.applyTransformation(transformation);
       }
     );

--- a/webroot/besogo/js/toolPanel.js
+++ b/webroot/besogo/js/toolPanel.js
@@ -622,7 +622,7 @@ besogo.makeToolPanel = function (container, editor) {
           function () {
             displayScoreEstimatingResult("b");
           },
-          "besogo-score-wins-a"
+          "besogo-se-winner-black"
         );
 
         makeButtonText(
@@ -631,7 +631,7 @@ besogo.makeToolPanel = function (container, editor) {
           function () {
             displayScoreEstimatingResult("w");
           },
-          "besogo-score-wins-b"
+          "besogo-se-winner-white"
         );
         makeButtonText(
           "-",
@@ -719,7 +719,7 @@ besogo.makeToolPanel = function (container, editor) {
           if (el.length) el.val(swapColorWords(el.val()));
         });
         // Score-estimating result buttons and summary labels.
-        ["besogo-score-wins-a", "besogo-score-wins-b"].forEach(function (id) {
+        ["besogo-se-winner-black", "besogo-se-winner-white"].forEach(function (id) {
           let el = $("#" + id);
           if (el.length) el.val(swapColorWords(el.val()));
         });

--- a/webroot/besogo/js/toolPanel.js
+++ b/webroot/besogo/js/toolPanel.js
@@ -617,21 +617,21 @@ besogo.makeToolPanel = function (container, editor) {
       if (setID != 262)
       {
         makeButtonText(
-          besogo.boardInverted ? besogo.swapColorWords("Black wins") : "Black wins",
+          besogo.boardInverted ? "White wins" : "Black wins",
           "",
           function () {
             displayScoreEstimatingResult("b");
           },
-          "besogo-se-winner-black"
+          "besogo-se-black"
         );
 
         makeButtonText(
-          besogo.boardInverted ? besogo.swapColorWords("White wins") : "White wins",
+          besogo.boardInverted ? "Black wins" : "White wins",
           "",
           function () {
             displayScoreEstimatingResult("w");
           },
-          "besogo-se-winner-white"
+          "besogo-se-white"
         );
         makeButtonText(
           "-",
@@ -719,7 +719,7 @@ besogo.makeToolPanel = function (container, editor) {
           if (el.length) el.val(swapColorWords(el.val()));
         });
         // Score-estimating result buttons and summary labels.
-        ["besogo-se-winner-black", "besogo-se-winner-white"].forEach(function (id) {
+        ["besogo-se-black", "besogo-se-white"].forEach(function (id) {
           let el = $("#" + id);
           if (el.length) el.val(swapColorWords(el.val()));
         });

--- a/webroot/besogo/js/toolPanel.js
+++ b/webroot/besogo/js/toolPanel.js
@@ -661,7 +661,7 @@ besogo.makeToolPanel = function (container, editor) {
       makeHyperlinkText("Back","previous problem", previousButtonLink, prevButtonId);
 
       makeButtonText(
-        besogo.boardInverted ? besogo.swapColorWords("Black is dead") : "Black is dead",
+        besogo.boardInverted ? "White is dead" : "Black is dead",
         "",
         function () {
           displayMultipleChoiceResult(1);
@@ -670,7 +670,7 @@ besogo.makeToolPanel = function (container, editor) {
       );
 
       makeButtonText(
-        besogo.boardInverted ? besogo.swapColorWords("White is dead") : "White is dead",
+        besogo.boardInverted ? "Black is dead" : "White is dead",
         "",
         function () {
           displayMultipleChoiceResult(2);

--- a/webroot/css/page/play.css
+++ b/webroot/css/page/play.css
@@ -396,8 +396,8 @@ h1 {
 #besogo-multipleChoice2,
 #besogo-multipleChoice3,
 #besogo-multipleChoice4,
-#besogo-se-black,
-#besogo-se-white,
+#besogo-score-wins-a,
+#besogo-score-wins-b,
 
 #besogo-se-more,
 #besogo-se-less {
@@ -462,8 +462,8 @@ h1 {
 #besogo-multipleChoice2:hover,
 #besogo-multipleChoice3:hover,
 #besogo-multipleChoice4:hover,
-#besogo-se-black:hover,
-#besogo-se-white:hover,
+#besogo-score-wins-a:hover,
+#besogo-score-wins-b:hover,
 #besogo-se-more:hover,
 #besogo-se-less:hover,
 #submitScoreEstimatingSE:hover, #submitScoreEstimatingBlackWins:hover, #submitScoreEstimatingWhiteWins:hover, #submitScoreEstimatingJigo:hover {

--- a/webroot/css/page/play.css
+++ b/webroot/css/page/play.css
@@ -396,8 +396,8 @@ h1 {
 #besogo-multipleChoice2,
 #besogo-multipleChoice3,
 #besogo-multipleChoice4,
-#besogo-se-winner-black,
-#besogo-se-winner-white,
+#besogo-se-black,
+#besogo-se-white,
 
 #besogo-se-more,
 #besogo-se-less {
@@ -462,8 +462,8 @@ h1 {
 #besogo-multipleChoice2:hover,
 #besogo-multipleChoice3:hover,
 #besogo-multipleChoice4:hover,
-#besogo-se-winner-black:hover,
-#besogo-se-winner-white:hover,
+#besogo-se-black:hover,
+#besogo-se-white:hover,
 #besogo-se-more:hover,
 #besogo-se-less:hover,
 #submitScoreEstimatingSE:hover, #submitScoreEstimatingBlackWins:hover, #submitScoreEstimatingWhiteWins:hover, #submitScoreEstimatingJigo:hover {

--- a/webroot/css/page/play.css
+++ b/webroot/css/page/play.css
@@ -396,8 +396,8 @@ h1 {
 #besogo-multipleChoice2,
 #besogo-multipleChoice3,
 #besogo-multipleChoice4,
-#besogo-score-wins-a,
-#besogo-score-wins-b,
+#besogo-se-winner-black,
+#besogo-se-winner-white,
 
 #besogo-se-more,
 #besogo-se-less {
@@ -462,8 +462,8 @@ h1 {
 #besogo-multipleChoice2:hover,
 #besogo-multipleChoice3:hover,
 #besogo-multipleChoice4:hover,
-#besogo-score-wins-a:hover,
-#besogo-score-wins-b:hover,
+#besogo-se-winner-black:hover,
+#besogo-se-winner-white:hover,
 #besogo-se-more:hover,
 #besogo-se-less:hover,
 #submitScoreEstimatingSE:hover, #submitScoreEstimatingBlackWins:hover, #submitScoreEstimatingWhiteWins:hover, #submitScoreEstimatingJigo:hover {


### PR DESCRIPTION
migration of all tsumego description to be in true color (in color of the first move rom tsumego)


edit form displays whatever colors puzzle is currently in, on save they are normalized

Fixes https://tsumego.com/forums/viewtopic.php?t=90

<img width="735" height="596" alt="image" src="https://github.com/user-attachments/assets/4ca869a1-55c4-4c73-91d5-06c4557a8696" />

<img width="717" height="591" alt="image" src="https://github.com/user-attachments/assets/9d40b9eb-1339-41a4-9fd6-0320ba120189" />
