### PR TITLE
fix: make Favorites menu visible to all logged-in users (forum#115)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -439,7 +439,6 @@ class AppController extends Controller
 		$levelBar = 1;
 		$lastProfileLeft = 1;
 		$lastProfileRight = 2;
-		$hasFavs = false;
 
 		if (Auth::isLoggedIn())
 		{
@@ -584,7 +583,6 @@ class AppController extends Controller
 		$this->set('lastProfileLeft', $lastProfileLeft);
 		$this->set('lastProfileRight', $lastProfileRight);
 		$this->set('resetCookies', $resetCookies);
-		$this->set('hasFavs', $hasFavs);
 		$this->set('timeMode', $timeMode);
 		if (Auth::isLoggedIn())
 			Auth::saveUser();

--- a/src/Controller/SetsController.php
+++ b/src/Controller/SetsController.php
@@ -731,7 +731,7 @@ class SetsController extends AppController
 				$this->set('formRedirect', true);
 			}
 		}
-		elseif ($tsumegoFilters->query = 'favorites')
+		elseif ($tsumegoFilters->query == 'favorites')
 		{
 			$allUts = $this->TsumegoStatus->find('all', ['conditions' => ['user_id' => Auth::getUserID()]]) ?: [];
 			$idMap = [];

--- a/src/Controller/SetsController.php
+++ b/src/Controller/SetsController.php
@@ -591,6 +591,7 @@ class SetsController extends AppController
 		}
 		elseif ($tsumegoFilters->query == 'tags')
 		{
+			$set = [];
 			$set['Set']['id'] = $id;
 			$set['Set']['image'] = '';
 			$set['Set']['multiplier'] = 1;
@@ -789,6 +790,8 @@ class SetsController extends AppController
 			$set['Set']['dateColor'] = '#eee';
 			$this->set('isFav', true);
 		}
+		else
+			throw new AppException('Unknown query type: ' . $tsumegoFilters->query);
 
 		if ($tsumegoButtons->description)
 			$set['Set']['description'] = $tsumegoButtons->description;

--- a/src/Utility/TsumegoButtonsQueryBuilder.php
+++ b/src/Utility/TsumegoButtonsQueryBuilder.php
@@ -100,7 +100,11 @@ class TsumegoButtonsQueryBuilder
 		$currentTag = $_COOKIE['lastSet'] ?? '';
 		$tag = ClassRegistry::init('Tag')->find('first', ['conditions' => ['name' => $currentTag]]);
 		if (!$tag)
-			throw new Exception("The tag selected to view ('.$currentTag.') couldn't be found");
+		{
+			// when we get bad lastSet value, we fallback to showing by topics (the set of current tsumego)
+			$this->tsumegoFilters->query = 'topics';
+			return;
+		}
 		$this->query->query .= ' LEFT JOIN tag_connection ON tag_connection.tsumego_id=tsumego.id';
 		$this->query->conditions[] = 'tag_connection.tag_id=' . $tag['Tag']['id'];
 	}

--- a/src/Utility/TsumegoFilters.php
+++ b/src/Utility/TsumegoFilters.php
@@ -61,7 +61,13 @@ class TsumegoFilters
 
 		// Apply new value if provided
 		if ($newValue)
+		{
 			$stringResult = $newValue;
+			// Clear the cookie override so subsequent requests
+			// read from preferences instead of stale cookie value.
+			if (!empty($_COOKIE[$name]) && $_COOKIE[$name] !== $newValue)
+				Util::clearCookie($name);
+		}
 
 		// Save back to preferences if value changed or was overridden
 		Preferences::set($name, $stringResult);

--- a/src/Utility/TsumegoFilters.php
+++ b/src/Utility/TsumegoFilters.php
@@ -65,7 +65,7 @@ class TsumegoFilters
 			$stringResult = $newValue;
 			// Clear the cookie override so subsequent requests
 			// read from preferences instead of stale cookie value.
-			if (!empty($_COOKIE[$name]) && $_COOKIE[$name] !== $newValue)
+			if (!empty($_COOKIE[$name]))
 				Util::clearCookie($name);
 		}
 

--- a/src/View/Layouts/default.ctp
+++ b/src/View/Layouts/default.ctp
@@ -219,25 +219,23 @@ echo $this->AssetCompress->script('app');
 						echo '</li>';
 						echo '<li><a '.$refreshLinkToSets.' '.$collectionsA.' href="/sets">Collections</a>';
 						if(Auth::isLoggedIn()){
-							if(Auth::hasPremium() || Auth::isAdmin() || $hasFavs){
-								echo '<ul class="newMenuLi2">';
-								if(Auth::hasPremium() || Auth::isAdmin())
-									echo '<li><a '.$refreshLinkToSandbox.' '.$sandboxA.' href="/sets/sandbox">Sandbox</a></li>';
-								echo '<li><a '.$refreshLinkToFavs.' href="/sets/view/favorites">Favorites</a></li>';
-								if(Auth::isAdmin()){
-									echo '<li><a class="adminLink" href="/users/adminstats">Activities</a></li>';
-										echo '<li><a class="adminLink" href="/tsumego-issues">Issues</a></li>';
-									echo '<li class="additional-adminLink2"><a id="adminLink-more" class="adminLink adminLink3"><i>more</i></a></li>';
-									echo '<li class="additional-adminLink"><a class="adminLink" href="/users/uploads">Uploads</a></li>';
-									echo '<li class="additional-adminLink"><a class="adminLink" href="/tsumegos/mergeForm">Merge Duplicates</a></li>';
-									echo '<li class="additional-adminLink"><a class="adminLink" href="/sets/duplicatesearch">Duplicate Search Results</a></li>';
-									echo '<li class="additional-adminLink"><a class="adminLink" href="/users/showPublishSchedule">Publish Schedule</a></li>';
-									echo '<li class="additional-adminLink"><a class="adminLink" href="/app/webroot/editor">Editor</a></li>';
-									echo '<li class="additional-adminLink"><a class="adminLink" href="/users/userstats">User Activities</a></li>';
-								}
-								echo '</ul>';
-								}
-								}
+							echo '<ul class="newMenuLi2">';
+							if(Auth::hasPremium() || Auth::isAdmin())
+								echo '<li><a '.$refreshLinkToSandbox.' '.$sandboxA.' href="/sets/sandbox">Sandbox</a></li>';
+							echo '<li><a '.$refreshLinkToFavs.' href="/sets/view/favorites">Favorites</a></li>';
+							if(Auth::isAdmin()){
+								echo '<li><a class="adminLink" href="/users/adminstats">Activities</a></li>';
+									echo '<li><a class="adminLink" href="/tsumego-issues">Issues</a></li>';
+								echo '<li class="additional-adminLink2"><a id="adminLink-more" class="adminLink adminLink3"><i>more</i></a></li>';
+								echo '<li class="additional-adminLink"><a class="adminLink" href="/users/uploads">Uploads</a></li>';
+								echo '<li class="additional-adminLink"><a class="adminLink" href="/tsumegos/mergeForm">Merge Duplicates</a></li>';
+								echo '<li class="additional-adminLink"><a class="adminLink" href="/sets/duplicatesearch">Duplicate Search Results</a></li>';
+								echo '<li class="additional-adminLink"><a class="adminLink" href="/users/showPublishSchedule">Publish Schedule</a></li>';
+								echo '<li class="additional-adminLink"><a class="adminLink" href="/app/webroot/editor">Editor</a></li>';
+								echo '<li class="additional-adminLink"><a class="adminLink" href="/users/userstats">User Activities</a></li>';
+							}
+							echo '</ul>';
+						}
 						$sessionLastVisit = $_COOKIE['lastVisit'] ?? 15352;
 						echo '</li>';
 						echo '<li><a class="homeMenuLink" '.$playA.' href="/tsumegos/play/'.$lv.'">Play</a>';

--- a/tests/ContextPreparator.php
+++ b/tests/ContextPreparator.php
@@ -8,6 +8,7 @@ class ContextPreparator
 	{
 		ClassRegistry::init('TagConnection')->deleteAll(['1 = 1']);      // FK to: user, tag
 		ClassRegistry::init('Tag')->deleteAll(['1 = 1']);                // FK to: user
+		ClassRegistry::init('Favorite')->deleteAll(['1 = 1']);           // FK to: user, tsumego
 		ClassRegistry::init('Schedule')->deleteAll(['1 = 1']);           // FK to: Tsumego, Set
 		ClassRegistry::init('ProgressDeletion')->deleteAll(['1 = 1']);   // FK to: User, Set
 		ClassRegistry::init('DayRecord')->deleteAll(['1 = 1']);          // FK to: User

--- a/tests/TestCase/Controller/SetsControllerTest.php
+++ b/tests/TestCase/Controller/SetsControllerTest.php
@@ -941,7 +941,6 @@ class SetsControllerTest extends TestCaseWithAuth
 
 	public function testAddingToFavoritesAndViewingIt(): void
 	{
-		ClassRegistry::init('Favorite')->deleteAll(['1 = 1']);
 		$contextParams = [];
 		for ($i = 0; $i < 3; $i++)
 			$contextParams ['tsumegos'] [] = ['sets' => [['name' => 'set ' . $i, 'num' => $i]]];
@@ -968,7 +967,6 @@ class SetsControllerTest extends TestCaseWithAuth
 
 	public function testRemovingFavorites(): void
 	{
-		ClassRegistry::init('Favorite')->deleteAll(['1 = 1']);
 		$contextParams = [];
 		$contextParams['user'] = ['mode' => Constants::$LEVEL_MODE];
 		for ($i = 0; $i < 3; $i++)
@@ -994,7 +992,6 @@ class SetsControllerTest extends TestCaseWithAuth
 
 	public function testGoingFromFavoritesToSetIndexResetsTheFavoritesQuery(): void
 	{
-		ClassRegistry::init('Favorite')->deleteAll(['1 = 1']);
 		$contextParams = [];
 		$contextParams['user'] = ['mode' => Constants::$LEVEL_MODE, 'query' => 'favorites'];
 		for ($i = 0; $i < 3; $i++)
@@ -1011,7 +1008,6 @@ class SetsControllerTest extends TestCaseWithAuth
 
 	public function testBrowsingFavoritesByNextButton(): void
 	{
-		ClassRegistry::init('Favorite')->deleteAll(['1 = 1']);
 		$contextParams = [];
 		$contextParams['user'] = ['mode' => Constants::$LEVEL_MODE, 'query' => 'favorites'];
 		for ($i = 0; $i < 5; $i++)
@@ -1397,5 +1393,18 @@ class SetsControllerTest extends TestCaseWithAuth
 		$browser->clickId("submit-size-button");
 		$tsumegoFilters = new TsumegoFilters();
 		$this->assertSame(60, $tsumegoFilters->collectionSize);
+	}
+
+	/**
+	 * Verify that Favorites menu item appears for all logged-in users,
+	 * even those without any favorites yet.
+	 */
+	public function testFavoritesMenuVisibleForAllLoggedInUsers(): void
+	{
+		new ContextPreparator(['user' => ['name' => 'regularuser']]);
+		$browser = Browser::instance();
+		$browser->get('/');
+		$pageSource = $browser->driver->getPageSource();
+		$this->assertStringContainsString('href="/sets/view/favorites"', $pageSource, 'Favorites link should be in the page HTML for logged-in users');
 	}
 }

--- a/tests/TestCase/Controller/TsumegosControllerTest.php
+++ b/tests/TestCase/Controller/TsumegosControllerTest.php
@@ -366,4 +366,22 @@ class TsumegosControllerTest extends TestCaseWithAuth
 		$currentUrl = $browser->driver->getCurrentURL();
 		$this->assertStringContainsString($secondTsumegoUrl, $currentUrl, "Should navigate to next puzzle");
 	}
+
+	/**
+	 * When in tags query mode but the lastSet cookie contains a value that
+	 * isn't a valid tag name, the play page should fall back to topics
+	 * view instead of crashing.
+	 */
+	public function testPlayPageFallsBackToTopicsWhenLastSetCookieIsNotAValidTag(): void
+	{
+		$context = new ContextPreparator([
+			'user' => ['mode' => Constants::$LEVEL_MODE, 'query' => 'tags'],
+			'tsumego' => ['sets' => [['name' => 'test set', 'num' => 1]]],
+		]);
+		$browser = Browser::instance();
+		$browser->setCookie('lastSet', 'nonexistent-tag');
+		$browser->get('/' . $context->tsumegos[0]['set-connections'][0]['id']);
+		$playTitle = $browser->driver->findElements(WebDriverBy::cssSelector('#playTitle'));
+		$this->assertCount(1, $playTitle, 'Play page should render with playTitle element');
+	}
 }


### PR DESCRIPTION
fixes https://tsumego.com/forums/viewtopic.php?t=115

according to commit [made all content available on non-premium except sandbox](https://github.com/kovarex/tsumego-hero/commit/ab811871edc3dacfbfc2ecbdeb715acc434e5675) enabled the collection/favorites menu for non-premium users


fixed contextpreparator deleting of favorites in favorites related tests