### PR TITLE
fix: validate filter values to prevent crash on invalid ranks/sets/tags (forum#120)

### DIFF
--- a/.ddev.example/php/php.ini
+++ b/.ddev.example/php/php.ini
@@ -1,4 +1,9 @@
 opcache.jit=disable
+
+; Show function arguments in exception stack traces (critical for debugging bug reports)
+zend.exception_ignore_args=Off
+zend.exception_string_param_max_len=100
+
 [xdebug]
 xdebug.mode=debug
 xdebug.client_host=<your local ip address goes here>

--- a/src/Utility/Rating.php
+++ b/src/Utility/Rating.php
@@ -14,16 +14,32 @@ class Rating
 		return (string) ($rank - 30) . 'd';
 	}
 
+	public static function isValidReadableRank(string $readableRank): bool
+	{
+		if (strlen($readableRank) < 2)
+			return false;
+		$suffix = substr($readableRank, -1);
+		$numberStr = substr($readableRank, 0, -1);
+		if (!ctype_digit($numberStr))
+			return false;
+		$number = (int) $numberStr;
+		if ($suffix === 'k')
+			return $number >= 1 && $number <= 30;
+		if ($suffix === 'd')
+			return $number >= 1;
+		return false;
+	}
+
 	public static function getRankFromReadableRank(string $readableRank): int
 	{
 		$suffix = substr($readableRank, -1);
 		$number = substr($readableRank, 0, -1);
-		if (!is_numeric($number))
+		if (!ctype_digit($number))
 			throw new RatingParseException($readableRank . " can't be parsed as go rank.");
-		if ($suffix == 'k')
-			return 31 - $number;
-		elseif ($suffix == 'd')
-			return 30 + $number;
+		if ($suffix === 'k')
+			return 31 - (int) $number;
+		elseif ($suffix === 'd')
+			return 30 + (int) $number;
 		else
 			throw new RatingParseException($readableRank . " can't be parsed as go rank.");
 	}

--- a/src/Utility/TsumegoFilters.php
+++ b/src/Utility/TsumegoFilters.php
@@ -2,6 +2,7 @@
 
 App::uses('Preferences', 'Utility');
 App::uses('Query', 'Utility');
+App::uses('Rating', 'Utility');
 
 class TsumegoFilters
 {
@@ -17,23 +18,31 @@ class TsumegoFilters
 
 		$this->query = self::processItem('query', 'topics', null, $newQuery);
 		$this->collectionSize = (int) self::processItem('collection_size', '200');
-		$this->sets = self::processItem('filtered_sets', [], function ($input) { return array_values(array_filter(explode('@', $input))); });
+		$rawSets = self::processItem('filtered_sets', [], function ($input) { return array_values(array_filter(explode('@', $input))); });
 
-		foreach ($this->sets as $set)
+		foreach ($rawSets as $set)
 		{
 			$found = ClassRegistry::init('Set')->find('first', ['conditions' => ['title' => $set, 'public' => 1]]);
 			if ($found)
+			{
+				$this->sets[] = $set;
 				$this->setIDs[] = $found['Set']['id'];
+			}
 		}
 
-		$this->ranks = self::processItem('filtered_ranks', [], function ($input) { return array_values(array_filter(explode('@', $input))); });
-		$this->tags = self::processItem('filtered_tags', [], function ($input) { return array_values(array_filter(explode('@', $input))); });
+		$this->ranks = self::processItem('filtered_ranks', [], function ($input) {
+			return array_values(array_filter(explode('@', $input), fn($rank) => Rating::isValidReadableRank($rank)));
+		});
+		$rawTags = self::processItem('filtered_tags', [], function ($input) { return array_values(array_filter(explode('@', $input))); });
 
-		foreach ($this->tags as $tag)
+		foreach ($rawTags as $tag)
 		{
 			$found = ClassRegistry::init('Tag')->findByName($tag);
 			if ($found)
+			{
+				$this->tags[] = $tag;
 				$this->tagIDs[] = $found['Tag']['id'];
+			}
 		}
 	}
 

--- a/src/View/Errors/error.ctp
+++ b/src/View/Errors/error.ctp
@@ -88,7 +88,44 @@ $this->set('title_for_layout', $errorTitle);
 			<?php if (method_exists($error, 'getTrace')): ?>
 				<div style="margin-top: 20px;">
 					<strong style="color: var(--text-color, #333); display: block; padding: 10px; background: rgba(0, 0, 0, 0.03); border-radius: 4px;">Stack Trace</strong>
-					<pre style="overflow: auto; max-height: 500px; background: rgba(0, 0, 0, 0.8); color: #f8f8f2; padding: 20px; border-radius: 5px; font-size: 13px; line-height: 1.6; margin-top: 10px; font-family: 'Consolas', 'Monaco', monospace;"><?php echo h($error->getTraceAsString()); ?></pre>
+					<pre style="overflow: auto; max-height: 500px; background: rgba(0, 0, 0, 0.8); color: #f8f8f2; padding: 20px; border-radius: 5px; font-size: 13px; line-height: 1.6; margin-top: 10px; font-family: 'Consolas', 'Monaco', monospace;"><?php
+						// Build trace with #-1 throw location
+						$traceLines = [];
+						$traceLines[] = '#-1 ' . h($error->getFile()) . '(' . h($error->getLine()) . ')';
+						foreach ($error->getTrace() as $i => $frame) {
+							$line = '#' . $i . ' ';
+							$line .= ($frame['file'] ?? '[internal function]') . '(' . ($frame['line'] ?? '') . '): ';
+							if (!empty($frame['class']))
+								$line .= $frame['class'] . ($frame['type'] ?? '->');
+							$line .= $frame['function'] . '(';
+							if (!empty($frame['args']))
+							{
+								$args = [];
+								foreach ($frame['args'] as $arg)
+								{
+									if (is_string($arg))
+										$args[] = "'" . (strlen($arg) > 50 ? substr($arg, 0, 50) . '...' : $arg) . "'";
+									elseif (is_numeric($arg))
+										$args[] = $arg;
+									elseif (is_bool($arg))
+										$args[] = $arg ? 'true' : 'false';
+									elseif (is_null($arg))
+										$args[] = 'NULL';
+									elseif (is_array($arg))
+										$args[] = 'Array';
+									elseif (is_object($arg))
+										$args[] = 'Object(' . get_class($arg) . ')';
+									else
+										$args[] = gettype($arg);
+								}
+								$line .= implode(', ', $args);
+							}
+							$line .= ')';
+							$traceLines[] = h($line);
+						}
+						$traceLines[] = '#' . count($error->getTrace()) . ' {main}';
+						echo implode("\n", $traceLines);
+					?></pre>
 				</div>
 			<?php endif; ?>
 		</div>

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -1690,6 +1690,7 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 		{
 			failAlreadyReported = true;
 			misplays++;
+			setCookie("misplays", misplays);
 			// Don't lock board - let user keep trying
 			if (mode != 2)
 			{
@@ -1727,7 +1728,10 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 						}
 					}
 					if (goldenTsumego)
+					{
 						window.location.href = '/' + '<?php echo $setConnection['SetConnection']['id']; ?>';
+						return;
+					}
 				}
 			}
 			else
@@ -1750,7 +1754,6 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 					freePlayMode = true;
 				}
 			}
-			setCookie("misplays", misplays);
 		}
 	}
 

--- a/tests/TestCase/Controller/SetsControllerTest.php
+++ b/tests/TestCase/Controller/SetsControllerTest.php
@@ -1507,5 +1507,24 @@ class SetsControllerTest extends TestCaseWithAuth
 		new ContextPreparator($contextParams);
 		$this->testAction('sets', ['return' => 'view']);
 		$this->assertTextContains('15k', $this->view);
+		$this->assertTextNotContains('nonexistent-set-that-was-deleted', $this->view);
 	}
+
+	public function testIndexWithInvalidRankDoesNotCrash(): void
+	{
+		$contextParams = ['user' => [
+			'mode' => Constants::$LEVEL_MODE,
+			'query' => 'difficulty',
+			'filtered_ranks' => ['deleted', '15k']]];
+		$contextParams['tsumegos'] = [];
+		$contextParams['tsumegos'][] = [
+			'rating' => Rating::getRankMiddleRatingFromReadableRank('15k'),
+			'sets' => [['name' => 'TestSet', 'num' => '1']]];
+
+		new ContextPreparator($contextParams);
+		$this->testAction('sets', ['return' => 'view']);
+		$this->assertTextContains('15k', $this->view);
+		$this->assertTextNotContains('deleted', $this->view);
+	}
+
 }

--- a/tests/TestCase/Utility/RatingTest.php
+++ b/tests/TestCase/Utility/RatingTest.php
@@ -35,4 +35,23 @@ class RatingTest extends CakeTestCase
 		$this->assertSame(Rating::getRankMinimalRatingFromReadableRank("9d"), 2780.0);
 		$this->assertSame(Rating::getRankMinimalRatingFromReadableRank("10d"), 2810.0);
 	}
+
+	public function testIsValidReadableRank(): void
+	{
+		$this->assertTrue(Rating::isValidReadableRank('15k'));
+		$this->assertTrue(Rating::isValidReadableRank('1k'));
+		$this->assertTrue(Rating::isValidReadableRank('30k'));
+		$this->assertTrue(Rating::isValidReadableRank('1d'));
+		$this->assertTrue(Rating::isValidReadableRank('9d'));
+		$this->assertTrue(Rating::isValidReadableRank('10d'));
+
+		$this->assertFalse(Rating::isValidReadableRank('deleted'));
+		$this->assertFalse(Rating::isValidReadableRank(''));
+		$this->assertFalse(Rating::isValidReadableRank('abc'));
+		$this->assertFalse(Rating::isValidReadableRank('k'));
+		$this->assertFalse(Rating::isValidReadableRank('0k'));
+		$this->assertFalse(Rating::isValidReadableRank('31k'));
+		$this->assertFalse(Rating::isValidReadableRank('1.5k'));
+		$this->assertFalse(Rating::isValidReadableRank('2.0d'));
+	}
 }


### PR DESCRIPTION
https://tsumego.com/forums/viewtopic.php?t=120

This error started coming up today. I can't access the collections page.


Exception

deleted can't be parsed as go rank.
#-1 /home/public/src/Utility/Rating.php(22)
#0 /home/public/src/Utility/Rating.php(65): Rating::getRankFromReadableRank('deleted')
#1 /home/public/src/Utility/RatingBounds.php(52): Rating::getRankMinimalRatingFromReadableRank('deleted')
#2 /home/public/src/Utility/TsumegoFilters.php(125): RatingBounds::coverRank('deleted', '15k')
#3 /home/public/src/Utility/TsumegoFilters.php(159): TsumegoFilters->filterRanks(Object(Query))
#4 /home/public/src/Utility/TsumegoFilters.php(167): TsumegoFilters->addConditionsToQuery(Object(Query))
#5 /home/public/src/Utility/SetsSelector.php(16): TsumegoFilters->calculateCount()
#6 /home/public/src/Controller/SetsController.php(286): SetsSelector->__construct(Object(TsumegoFilters))
#7 [internal function]: SetsController->index()
#8 /home/public/vendor/pieceofcake2/cakephp/src/Cake/Controller/Controller.php(503): ReflectionMethod->invokeArgs(Object(SetsController), Array)
#9 /home/public/vendor/pieceofcake2/cakephp/src/Cake/Routing/Dispatcher.php(190): Controller->invokeAction(Object(CakeRequest))
#10 /home/public/vendor/pieceofcake2/cakephp/src/Cake/Routing/Dispatcher.php(163): Dispatcher->_invoke(Object(SetsController), Object(CakeRequest))
#11 /home/public/webroot/index.php(70): Dispatcher->dispatch(Object(CakeRequest), Object(CakeResponse))
#12 {main}