### PR TITLE
feat: add status labels to tsumego button tooltips (forum#138)

### DIFF
--- a/src/Model/TsumegoStatus.php
+++ b/src/Model/TsumegoStatus.php
@@ -30,6 +30,38 @@ class TsumegoStatus extends AppModel
 		}
 	}
 
+	public static array $labels = [
+		'N' => 'Not visited',
+		'V' => 'Visited',
+		'S' => 'Solved',
+		'F' => 'Locked',
+		'W' => 'Review',
+		'C' => 'Mastered',
+		'X' => 'Forgotten',
+		'G' => 'Golden',
+	];
+
+	public static array $descriptions = [
+		'N' => 'You haven\'t seen this problem yet.',
+		'V' => 'You have seen this problem but have not solved it.',
+		'S' => 'You got it right. It gives no more XP and becomes available for Review after one week.',
+		'F' => 'You can\'t play this problem today after misplaying with no hearts left. It resets to Visited tomorrow.',
+		'W' => 'A week has passed since you solved this. Solve it for half XP. Get it right and it becomes Mastered, fail and it becomes Forgotten.',
+		'C' => 'You passed the review. It gives no more XP.',
+		'X' => 'You failed a Review. You are locked out for today. It resets to Review tomorrow.',
+		'G' => 'You have one attempt at 8x XP. Created by activating the Refinement hero power.',
+	];
+
+	public static function label(string $status): string
+	{
+		return self::$labels[$status] ?? '';
+	}
+
+	public static function description(string $status): string
+	{
+		return self::$descriptions[$status] ?? '';
+	}
+
 	public static function getProblemsSolvedInSet($setID)
 	{
 		return Util::query("

--- a/src/Utility/TsumegoButton.php
+++ b/src/Utility/TsumegoButton.php
@@ -1,5 +1,7 @@
 <?php
 
+App::uses('TsumegoStatus', 'Model');
+
 class TsumegoButton
 {
 	public function __construct(int $tsumegoID, int $setConnectionID, int $order, ?string $status, ?float $rating = 0)
@@ -52,7 +54,16 @@ class TsumegoButton
 		$num3 = '<div class="setViewButtons3">' . $num3 . '</div>';
 
 		echo '<li class="status' . ($this->status ?: 'N') . ($this->isCurrentlyOpened ? ' statusCurrent' : '') . '">';
-		echo '<a class="tooltip" href="/' . $this->setConnectionID . '" onmouseover="' . $this->generateTooltip() . '">' . $num . $num2 . $num3 . '<span class="tooltip-box"></span></a>';
+		$status = $this->status ?: 'N';
+		$label = TsumegoStatus::label($status);
+		$description = TsumegoStatus::description($status);
+		echo '<a class="tooltip" href="/' . $this->setConnectionID . '"'
+			. ' onmouseover="' . $this->generateTooltip() . '">'
+			. $num . $num2 . $num3
+			. '<span class="tooltip-box">'
+			. '<div class="tooltip-label status' . $status . '">' . h($label) . '</div>'
+			. '<div class="tooltip-desc">' . h($description) . '</div>'
+			. '</span></a>';
 		echo '</li>';
 	}
 

--- a/src/View/Sites/websitefunctions.ctp
+++ b/src/View/Sites/websitefunctions.ctp
@@ -122,60 +122,19 @@
 			<br>
 			<b>(5) Problem colors</b><br><br>
 		<table class="sitesTable">
+		<?php
+		foreach (TsumegoStatus::$labels as $status => $label):
+			$description = TsumegoStatus::$descriptions[$status] ?? '';
+		?>
 		<tr>
 			<td>
-				<img title="Not visited" alt="Not visited" src="/img/xN.png">
+				<span class="status-label status<?php echo $status; ?>"><?php echo h($label); ?></span>
 			</td>
 			<td>
-				<b>Not visited</b><br>
-				You haven't seen this problem.<br><br>
+				<?php echo h($description); ?><br><br>
 			</td>
 		</tr>
-		<tr>
-			<td>
-				<img title="Visited" alt="Visited" src="/img/xV.png">
-			</td>
-			<td>
-				<b>Visited</b><br>
-				You have seen this problem, but not solved.<br><br>
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<img title="Solved" alt="Solved" src="/img/xS.png">
-			</td>
-			<td>
-				<b>Solved</b><br>
-				You solved this problem.<br><br>
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<img title="Locked" alt="Locked" src="/img/xF.png">
-			</td>
-			<td>
-				<b>Locked</b><br>
-				This problem is locked for today. Problems get locked when a player misplays and has no more hearts left.<br><br>
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<img title="Half XP" alt="Half XP" src="/img/xW.png">
-			</td>
-			<td>
-				<b>Half XP</b><br>
-				This problem gives half XP. It becomes available one week after the first solution.<br><br>
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<img title="Golden" alt="Golden" src="/img/xG.png">
-			</td>
-			<td>
-				<b>Golden</b><br>
-				This is a golden tsumego. It gives eight times more XP than usual. If you fail, it disappears.<br><br>
-			</td>
-		</tr>
+		<?php endforeach; ?>
 		</table>
 
 		</div>

--- a/webroot/css/default.css
+++ b/webroot/css/default.css
@@ -386,23 +386,50 @@ li.statusN:hover { background-color: #a6a9b0; }
 li.statusV { background-color: var(--status-v-color); }
 li.statusV:hover { background-color: #74b5e0; }
 
-li.statusS,
-li.statusC { background-color: var(--status-solved-color); }
+li.statusS { background-color: var(--status-s-color); }
+li.statusS:hover { background-color: #5cd98a; }
 
-li.statusS:hover,
+li.statusC { background-color: var(--status-c-color); }
 li.statusC:hover { background-color: #6be39a; }
 
 li.statusW { background-color: var(--status-w-color); }
 li.statusW:hover { background-color: #7acfcd; }
 
-li.statusF,
-li.statusX { background-color: var(--status-failed-color); }
+li.statusF { background-color: var(--status-f-color); }
+li.statusF:hover { background-color: #e09da4; }
 
-li.statusF:hover,
-li.statusX:hover { background-color: #e09da4; }
+li.statusX { background-color: var(--status-x-color); }
+li.statusX:hover { background-color: #eaa8ae; }
 
-li.statusG { background-color: var(--status-g-color); }
-li.statusG:hover { background-color: #e5ee74; }
+li.statusG {
+  background:
+    linear-gradient(115deg, transparent 30%, rgba(255,255,255,0) 42%, rgba(255,255,255,0.4) 50%, rgba(255,255,255,0) 58%, transparent 70%),
+    linear-gradient(135deg, var(--status-g-color), var(--status-g-highlight), var(--status-g-color));
+  background-size: 250% 100%, 100% 100%;
+  background-position: 150% 0, 0 0;
+  animation: goldenShineSweep 3s ease-in-out infinite;
+}
+li.statusG:hover {
+  background:
+    linear-gradient(115deg, transparent 30%, rgba(255,255,255,0) 42%, rgba(255,255,255,0.5) 50%, rgba(255,255,255,0) 58%, transparent 70%),
+    linear-gradient(135deg, var(--status-g-highlight), #fff8c0, var(--status-g-highlight));
+  background-size: 250% 100%, 100% 100%;
+  background-position: 150% 0, 0 0;
+  animation: goldenShineSweep 1.5s ease-in-out infinite;
+}
+
+@keyframes goldenShineSweep {
+  0% { background-position: 150% 0, 0 0; }
+  100% { background-position: -50% 0, 0 0; }
+}
+
+@keyframes goldenShine {
+  0% { left: -75%; }
+  100% { left: 125%; }
+}
+
+li.statusG a { color: #4a3500; }
+li.statusG a:hover { color: #4a3500; }
 
 li a {
   display: block;
@@ -3372,7 +3399,7 @@ input.newCheck {
 }
 .xpDisplay { align:center; color: black; }
 .solvedXpDisplay { color: green; }
-.goldenTsumegoXpDisplay { color: #b5910b; font-weight:800; }
+.goldenTsumegoXpDisplay { color: #9a7b00; font-weight:800; text-shadow: 0 0 6px rgba(218, 165, 32, 0.4); }
 .sprintXpDisplay { color: blue; }
 
 #status h2,
@@ -3391,9 +3418,6 @@ input.newCheck {
 .tooltip span {
   z-index: 100;
   display: none;
-  position: relative;
-  top: 34px;
-  left: -1px;
 }
 .eloTooltip {
   position: relative;
@@ -7737,11 +7761,91 @@ ul ul {
 {
 	display: none;
 	position: absolute;
-	left: 100%;
-	top: 0;
+	top: 34px;
+	left: -1px;
 	z-index: 1000;
 	pointer-events: none;
 }
+
+.tooltip-box svg
+{
+	display: block;
+}
+
+.tooltip-label
+{
+	opacity: 0;
+	padding: 3px 8px;
+	font-size: 12px;
+	font-weight: 800;
+	text-align: center;
+	border-radius: 3px;
+	transition: opacity 0.2s ease;
+}
+
+.tooltip-desc
+{
+	opacity: 0;
+	padding: 4px 6px;
+	font-size: 10px;
+	color: #ddd;
+	text-align: center;
+	max-width: 180px;
+	transition: opacity 0.3s ease;
+	line-height: 1.3;
+	background: rgba(0, 0, 0, 0.8);
+	border-radius: 0 0 3px 3px;
+}
+
+.tooltip-label.statusN,
+.status-label.statusN { background-color: var(--status-n-color); color: #fff; }
+.tooltip-label.statusV,
+.status-label.statusV { background-color: var(--status-v-color); color: #fff; }
+.tooltip-label.statusS,
+.status-label.statusS { background-color: var(--status-s-color); color: #fff; }
+.tooltip-label.statusC,
+.status-label.statusC { background-color: var(--status-c-color); color: #fff; }
+.tooltip-label.statusW,
+.status-label.statusW { background-color: var(--status-w-color); color: #fff; }
+.tooltip-label.statusF,
+.status-label.statusF { background-color: var(--status-f-color); color: #fff; }
+.tooltip-label.statusX,
+.status-label.statusX { background-color: var(--status-x-color); color: #fff; }
+.tooltip-label.statusG,
+.status-label.statusG {
+  background: linear-gradient(135deg, var(--status-g-color), var(--status-g-highlight), var(--status-g-color));
+  color: #3d2e00;
+  box-shadow: 0 1px 4px rgba(218, 165, 32, 0.5), inset 0 1px 0 rgba(255,255,255,0.3);
+  border: 1px solid rgba(180, 140, 30, 0.4);
+  position: relative;
+  overflow: hidden;
+}
+.tooltip-label.statusG::after,
+.status-label.statusG::after {
+  content: "";
+  position: absolute;
+  top: -50%;
+  left: -75%;
+  width: 40%;
+  height: 200%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent);
+  transform: skewX(-25deg);
+  animation: goldenShine 3s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.status-label
+{
+	display: inline-block;
+	padding: 4px 14px;
+	font-size: 14px;
+	font-weight: 800;
+	border-radius: 4px;
+	text-align: center;
+	min-width: 100px;
+}
+
+
 
 .paginator-link
 {
@@ -8000,12 +8104,15 @@ to { transform: rotate(360deg); }
 	--new1-gradient: linear-gradient(#fff, #f2f2f2);
 	--title4-gradient: linear-gradient(#e1e1e1, #bdbdbd);
 	--body-background-gradient: linear-gradient(#282828, #424141);
-	--status-solved-color: #3ecf78;
-	--status-failed-color: #c63f4d;
+	--status-s-color: #3ecf78;
+	--status-c-color: #27ae60;
+	--status-f-color: #c63f4d;
+	--status-x-color: #a8323c;
 	--status-w-color: #34cfcc;
 	--status-v-color: #2d98e0;
 	--status-n-color: #7f8287;
-	--status-g-color: #d7e062;
+	--status-g-color: #daa520;
+	--status-g-highlight: #f5e080;
 	--paginator-button-text-color: #333;
 	--active-paginator-button-background-color: #333;
 	--active-paginator-button-text-color: #fff;
@@ -8023,12 +8130,15 @@ to { transform: rotate(360deg); }
 	--new1-gradient: linear-gradient(#3c3c3c, #2a2a2a);
 	--title4-gradient: linear-gradient(#737373, #4a4a4a);
 	--body-background-gradient: linear-gradient(#2a2a2a, #111);
-	--status-solved-color: #0a4;
-	--status-failed-color: #dd3a4b;
+	--status-s-color: #0a4;
+	--status-c-color: #083;
+	--status-f-color: #dd3a4b;
+	--status-x-color: #c72a3b;
 	--status-w-color: #00aeab;
 	--status-v-color: #0088e3;
 	--status-n-color: #444;
-	--status-g-color: #b0bd00;
+	--status-g-color: #b8860b;
+	--status-g-highlight: #e8c840;
 	--paginator-button-text-color: #ccc;
 	--active-paginator-button-background-color: #ccc;
 	--active-paginator-button-text-color: #000;

--- a/webroot/js/previewBoard.js
+++ b/webroot/js/previewBoard.js
@@ -19,39 +19,45 @@
 	{
 		const w3 = "http://www.w3.org/2000/svg";
 		const w32 = "http://www.w3.org/1999/xlink";
-		let svg = document.createElementNS(w3,"svg");
-		let zoom = (xMax>=9||yMax>=13) ? false : true;
-		if(boardSize==13) zoom = false;
-		let size = zoom ? 6 : 4;
-		let border = zoom ? 3 : 2;
-		xMax = (xMax>=9) ? 19 : xMax+4;
-		let borderPixelsX = (xMax==19) ? size : size/2
-		yMax = (yMax>=13) ? 19 : yMax+4;
-		let borderPixelsY = (yMax==19) ? size : size/2;
-		let increment = size*2;
-		if(boardSize==13)
-		{
-			xMax = 13;
-			yMax = 13;
-		}
-		xMax = increment*xMax+borderPixelsX;
-		yMax = increment*yMax+borderPixelsY;
-		let xPos = size+border;
-		let yPos = size+border;
+		let svg = document.createElementNS(w3, "svg");
 
-		let img = zoom ? "/img/theBoard2.png" : "/img/theBoard.png";
-		if(boardSize==13) img = "/img/theBoard13x13.png"
-		else if(boardSize==9) img = "/img/theBoard9x9.png"
-		else if(boardSize==5) img = "/img/theBoard5x5.png"
-		else if(boardSize==4) img = "/img/theBoard4x4.png"
+		let img, size, border, increment;
+
+		if (boardSize <= 13)
+		{
+			// Small boards: render full board, ignore stone bounding box
+			let zoom = boardSize <= 9;
+			size = zoom ? 6 : 4;
+			border = size / 2;
+			increment = size * 2;
+			xMax = increment * boardSize + border;
+			yMax = xMax;
+			img = "/img/theBoard" + boardSize + "x" + boardSize + ".png";
+		}
+		else
+		{
+			// 19x19: crop to stone bounding box with padding
+			let zoom = (xMax >= 9 || yMax >= 13) ? false : true;
+			size = zoom ? 6 : 4;
+			border = zoom ? 3 : 2;
+			increment = size * 2;
+			xMax = (xMax >= 9) ? 19 : xMax + 4;
+			let bpx = (xMax == 19) ? size : size / 2;
+			yMax = (yMax >= 13) ? 19 : yMax + 4;
+			let bpy = (yMax == 19) ? size : size / 2;
+			xMax = increment * xMax + bpx;
+			yMax = increment * yMax + bpy;
+			img = zoom ? "/img/theBoard2.png" : "/img/theBoard.png";
+		}
+
 		setPreviewBoard(xMax, yMax, svg, img, w3, w32);
-		drawStoneString(black, "black", size, size,increment, border, svg, w3);
+		drawStoneString(black, "black", size, size, increment, border, svg, w3);
 		drawStoneString(white, "white", size, size, increment, border, svg, w3);
-		drawStoneString(diff, "red", size, size/2, increment, border, svg, w3);
+		drawStoneString(diff, "red", size, size / 2, increment, border, svg, w3);
 		svg.style.width = xMax + "px";
 		svg.style.height = yMax + "px";
 		let targetContainer = target.querySelector('span');
-		targetContainer.appendChild(svg);
+		targetContainer.insertBefore(svg, targetContainer.firstChild);
 	}
 
 	function createPreviewBoard(target, black, white, xMax=0, yMax=0, boardSize=19, diff = '')
@@ -85,15 +91,37 @@
 
 	function hoverForPreviewBoard(target)
 	{
+		let labelTimer = null;
+		let descTimer = null;
+
 		target.addEventListener("mouseenter", function () {
 			const span = this.querySelector('span');
 			span.style.display = "block";
 			span.style.position = "absolute";
 			span.style.overflow = "hidden";
+
+			const label = span.querySelector('.tooltip-label');
+			const desc = span.querySelector('.tooltip-desc');
+
+			labelTimer = setTimeout(() => {
+				if (label) label.style.opacity = "1";
+			}, 600);
+
+			descTimer = setTimeout(() => {
+				if (desc) desc.style.opacity = "1";
+			}, 1200);
 		});
 
 		target.addEventListener("mouseleave", function () {
 			const span = this.querySelector('span');
 			span.style.display = "none";
+
+			clearTimeout(labelTimer);
+			clearTimeout(descTimer);
+
+			const label = span.querySelector('.tooltip-label');
+			const desc = span.querySelector('.tooltip-desc');
+			if (label) label.style.opacity = "0";
+			if (desc) desc.style.opacity = "0";
 		});
 	}


### PR DESCRIPTION
<img width="622" height="148" alt="image" src="https://github.com/user-attachments/assets/9b60aced-8e1c-4a2a-9fea-d58bb9883716" />

<br>
<img width="118" height="196" alt="image" src="https://github.com/user-attachments/assets/8373d6a6-660a-4832-b1db-4a7b3e44f75f" />
<br>
<img width="623" height="593" alt="image" src="https://github.com/user-attachments/assets/6b133be7-1573-49c4-8eb5-1a6507951a91" />

I have renamed (W) Half XP -> Review, this way we can explain statuses in two triads W (Review), X (Forgotten) and C (Mastered) similar to V (Visited), F (Failed) and S (Solved))


hover over level instantly displays puzzle preview, then after some time status label, then after more time status description

sites/websitefunctions updated to use css instead of images and loop over status structure
