### PR TITLE
fix: Bad Potion achievement never triggers (Potion hero power doesn't work) (forum#142)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -187,10 +187,9 @@ class AppController extends Controller
 		ClassRegistry::init('AchievementCondition')->save($goldenCondition);
 	}
 
-	public static function setPotionCondition(): void
+	public static function updatePotionCondition(): void
 	{
 		$potionCondition = ClassRegistry::init('AchievementCondition')->find('first', [
-			'order' => 'value DESC',
 			'conditions' => [
 				'user_id' => Auth::getUserID(),
 				'category' => 'potion',
@@ -199,11 +198,12 @@ class AppController extends Controller
 		if (!$potionCondition)
 		{
 			$potionCondition = [];
+			$potionCondition['AchievementCondition']['value'] = 0;
 			ClassRegistry::init('AchievementCondition')->create();
 		}
 		$potionCondition['AchievementCondition']['category'] = 'potion';
 		$potionCondition['AchievementCondition']['user_id'] = Auth::getUserID();
-		$potionCondition['AchievementCondition']['value'] = 1;
+		$potionCondition['AchievementCondition']['value']++;
 		ClassRegistry::init('AchievementCondition')->save($potionCondition);
 	}
 
@@ -492,6 +492,7 @@ class AppController extends Controller
 		if (Auth::isLoggedIn() && !$this->request->is('ajax'))
 		{
 			$this->PlayResultProcessor->checkPreviousPlay($timeMode);
+			$this->set('potionSuccess', $this->PlayResultProcessor->processPotion());
 			$achievementChecker = new AchievementChecker();
 			$achievementChecker->checkLevelAchievements();
 			$achievementChecker->checkProblemNumberAchievements();

--- a/src/Controller/Component/Play.php
+++ b/src/Controller/Component/Play.php
@@ -3,7 +3,6 @@
 App::uses('SetNavigationButtonsInput', 'Utility');
 App::uses('TsumegoButton', 'Utility');
 App::uses('TsumegoButtons', 'Utility');
-App::uses('HeroPowers', 'Utility');
 App::uses('TsumegoXPAndRating', 'Utility');
 App::uses('Level', 'Utility');
 App::uses('AdminActivityLogger', 'Utility');
@@ -42,12 +41,9 @@ class Play
 		$half = '';
 		$isSandbox = false;
 		$goldenTsumego = false;
-		$potion = 0;
-		$potionSuccess = false;
 		$reviewCheat = false;
 		$commentCoordinates = [];
 		$trs = [];
-		$potionAlert = false;
 		$eloScore = 0;
 		$eloScore2 = 0;
 		$requestProblem = '';
@@ -73,9 +69,6 @@ class Play
 		$set = ClassRegistry::init('Set')->findById($currentSetConnection['SetConnection']['set_id']);
 
 		$tsumegoVariant = ClassRegistry::init('TsumegoVariant')->find('first', ['conditions' => ['tsumego_id' => $id]]);
-
-		if (isset($params['url']['potionAlert']))
-			$potionAlert = true;
 
 		if (isset($params['url']['search']))
 			if ($params['url']['search'] == 'topics')
@@ -194,9 +187,6 @@ class Play
 
 		if ($tsumegoStatus == 'G')
 			$goldenTsumego = true;
-
-		if (Auth::isLoggedIn() && Auth::getUser()['potion'] >= 15)
-			AppController::setPotionCondition();
 
 		Util::setCookie('previousTsumegoID', $id);
 
@@ -415,12 +405,9 @@ class Play
 		($this->setFunction)('activate', $activate);
 		($this->setFunction)('tsumegoElo', $t['Tsumego']['rating']);
 		($this->setFunction)('trs', $trs);
-		($this->setFunction)('potion', $potion);
-		($this->setFunction)('potionSuccess', $potionSuccess);
 		($this->setFunction)('reviewCheat', $reviewCheat);
 		($this->setFunction)('part', $t['Tsumego']['part']);
 		($this->setFunction)('checkBSize', $checkBSize);
-		($this->setFunction)('potionAlert', $potionAlert);
 		($this->setFunction)('file', $file);
 		($this->setFunction)('ui', $ui);
 		($this->setFunction)('requestProblem', $requestProblem);

--- a/src/Controller/Component/PlayResultProcessorComponent.php
+++ b/src/Controller/Component/PlayResultProcessorComponent.php
@@ -12,8 +12,6 @@ App::uses('Progress', 'Utility');
 
 class PlayResultProcessorComponent extends Component
 {
-	public $components = ['Session'];
-
 	public function checkPreviousPlay($timeModeComponent): void
 	{
 		$this->checkAddFavorite();
@@ -57,6 +55,42 @@ class PlayResultProcessorComponent extends Component
 		$this->updateTsumegoAttempt($previousTsumego, $result, $previousStatusValue);
 		$this->processErrorAchievement($result, $previousStatusValue);
 		$this->processUnsortedStuff($previousTsumego, $result);
+	}
+
+	/**
+	 * Potion: if the previous problem was failed with no hearts and potion is
+	 * available, there is a progressive chance to heal based on how far damage
+	 * exceeds max health: chance% = (damage - maxHealth) * POTION_CHANCE_PER_DEATH.
+	 * If it does NOT trigger, increments the Bad Potion counter so
+	 * AchievementChecker can award BAD_POTION.
+	 *
+	 * Called after checkPreviousPlay() so previousTsumegoBuffer cookie is set.
+	 * Healing and counter MUST happen here (before achievements) not in Play.php.
+	 */
+	public function processPotion(): bool
+	{
+		if (!Auth::isLoggedIn())
+			return false;
+		if (!HeroPowers::canPotionTrigger())
+			return false;
+		if (!in_array($_COOKIE['previousTsumegoBuffer'] ?? '', ['F', 'X'], true))
+			return false;
+
+		$excessDeaths = Auth::getUser()['damage'] - Util::getHealthBasedOnLevel(Auth::getUser()['level']);
+		$chance = min($excessDeaths * HeroPowers::$POTION_CHANCE_PER_DEATH, 100);
+
+		if (rand(1, 100) <= $chance)
+		{
+			Auth::getUser()['damage'] = 0;
+			Auth::getUser()['used_potion'] = 1;
+			// Original also reset Rejuvenation here:
+			// Auth::getUser()['used_rejuvenation'] = 0;
+			Auth::saveUser();
+			return true;
+		}
+
+		AppController::updatePotionCondition();
+		return false;
 	}
 
 	public function checkPreviousPlayAndGetResult(&$previousTsumego): array

--- a/src/Controller/CronController.php
+++ b/src/Controller/CronController.php
@@ -18,6 +18,7 @@ class CronController extends AppController
 		self::createDayRecord();
 		self::publish();
 		$this->dailyUsersReset();
+		$this->dailyPotionConditionReset();
 		$this->updatePopularTags();
 		$this->updateSolvedCounts();
 
@@ -40,6 +41,12 @@ class CronController extends AppController
 		$query .= ',readingTrial=30';
 		$query .= ',reuse4=0';
 		ClassRegistry::init('User')->query($query);
+	}
+
+	private function dailyPotionConditionReset()
+	{
+		ClassRegistry::init('AchievementCondition')->query(
+			"UPDATE achievement_condition SET value=0 WHERE category='potion'");
 	}
 
 	private function dailyTsumegoStatusReset()

--- a/src/Model/Achievement.php
+++ b/src/Model/Achievement.php
@@ -146,7 +146,7 @@ class Achievement extends AppModel
 	// Sprint/Gold/Potion
 	public const int SPRINT = 96;       // sprint >= 30
 	public const int GOLD_DIGGER = 97;  // golden >= 10
-	public const int BAD_POTION = 98;   // potion >= 1
+	public const int BAD_POTION = 98;
 
 	// Favorites
 	public const int FAVORITES = 99;

--- a/src/Utility/AchievementChecker.php
+++ b/src/Utility/AchievementChecker.php
@@ -143,7 +143,7 @@ class AchievementChecker
 			$this->gained(Achievement::SPRINT);
 		if ($ac1['golden'] >= 10)
 			$this->gained(Achievement::GOLD_DIGGER);
-		if ($ac1['potion'] >= 1)
+		if ($ac1['potion'] >= HeroPowers::$BAD_POTION_THRESHOLD)
 			$this->gained(Achievement::BAD_POTION);
 	}
 

--- a/src/Utility/HeroPowers.php
+++ b/src/Utility/HeroPowers.php
@@ -6,6 +6,8 @@ class HeroPowers
 	public static $INTUITION_MINIMUM_LEVEL = 30;
 	public static $REJUVENATION_MINIMUM_LEVEL = 40;
 	public static $POTION_MINIMUM_LEVEL = 50;
+	public static $POTION_CHANCE_PER_DEATH = 0.5;
+	public static $BAD_POTION_THRESHOLD = 15;
 	public static $REVELATION_MINIMUM_LEVEL = 80;
 	public static $REFINEMENT_MINIMUM_LEVEL = 100;
 
@@ -148,11 +150,11 @@ class HeroPowers
 		echo '<img id="sprint" title="Sprint: Double XP for 2 minutes." alt="Sprint"></a>';
 	}
 
-	public static function isPotionActive()
+	public static function canPotionTrigger()
 	{
 		if (!Auth::hasPremium() && Auth::getUser()['level'] < self::$POTION_MINIMUM_LEVEL)
 			return false;
-		if (!Auth::getUser()['used_potion'])
+		if (Auth::getUser()['used_potion'])
 			return false;
 		return Auth::getUser()['damage'] >= Util::getHealthBasedOnLevel(Auth::getUser()['level']);
 	}
@@ -171,7 +173,7 @@ class HeroPowers
 
 	private static function renderPotion()
 	{
-		if (self::isPotionActive())
+		if (self::canPotionTrigger())
 			echo '<img id="potion" title="Potion (Passive): If you misplay and have no hearts left, you have a small chance to restore your health." src="/img/hp5.png">';
 	}
 }

--- a/src/View/Tsumegos/play.ctp
+++ b/src/View/Tsumegos/play.ctp
@@ -523,7 +523,7 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 					</div>
 		</label>
 	<?php }else{ ?>
-		<?php if($potionAlert){ ?>
+		<?php if($potionSuccess){ ?>
 		<label>
 			<input type="checkbox" class="alertCheckbox1" id="potionAlertCheckbox" autocomplete="off" />
 			<div class="alertBox alertInfo" id="potionAlerts">
@@ -999,11 +999,8 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 			$("#scoreEstEditField").val(chars+num);
 		});
 	<?php } ?>
+
 	<?php
-	if($potionSuccess){
-		echo 'document.cookie = "rejuvenationx=2;path=/tsumegos/play;SameSite=Lax";';
-		echo 'window.location = "/tsumegos/play/'.$t['Tsumego']['id'].'?potionAlert=1";';
-	}
 	if(Auth::isInLevelMode()){
 	}elseif(Auth::isInRatingMode()){
 		echo '
@@ -1069,7 +1066,7 @@ if ($checkBSize != 19 || $t['Tsumego']['set_id'] == 239
 				tryAgainTomorrow = true;
 				document.getElementById("status").style.color = "#e03c4b";';
 	}
-		if($potionAlert){
+		if($potionSuccess){
 			echo '$(".alertBox").fadeIn(500);';
 	}
 		if($isSemeai){

--- a/tests/TestCase/Achievement/Unlock/SprintMiscAchievementTest.php
+++ b/tests/TestCase/Achievement/Unlock/SprintMiscAchievementTest.php
@@ -2,6 +2,7 @@
 
 App::uses('Achievement', 'Model');
 App::uses('AppController', 'Controller');
+App::uses('HeroPowers', 'Utility');
 App::uses('AchievementTestCase', 'TestCase/Achievement');
 App::uses('ContextPreparator', 'Test');
 
@@ -37,14 +38,25 @@ class SprintMiscAchievementTest extends AchievementTestCase
 	}
 
 	/**
-	 * Test Bad Potion achievement (ID 98): "Have the potion not triggered 15 times on the same day"
-	 * Actually checks potion >= 1 in code (not 15 as description says)
-	 * Requires achievement_condition with category='potion' and value >= 1
+	 * Test Bad Potion achievement checker (ID 98): "Have the potion not triggered
+	 * enough times on the same day." Requires achievement_condition with
+	 * category='potion' and value >= BAD_POTION_THRESHOLD.
+	 *
+	 * This tests only the AchievementChecker. The real trigger path
+	 * (updatePotionCondition incrementing the counter) is tested in
+	 * PlayResultProcessorComponentTest::testPotionConditionIncrementsOnPreviousFail.
 	 */
-	public function testBadPotionAchievement()
+	public function testBadPotionAchievementChecker(): void
 	{
-		$context = new ContextPreparator(['achievement-conditions' => [['category' => 'potion', 'value' => 1]]]);
+		$context = new ContextPreparator(['achievement-conditions' => [['category' => 'potion', 'value' => HeroPowers::$BAD_POTION_THRESHOLD]]]);
 		new AchievementChecker()->checkDanSolveAchievements();
-		$this->assertAchievementUnlocked(Achievement::BAD_POTION, 'Bad Potion achievement should unlock when potion condition >= 1');
+		$this->assertAchievementUnlocked(Achievement::BAD_POTION, 'Bad Potion checker should unlock when potion condition >= ' . HeroPowers::$BAD_POTION_THRESHOLD);
+	}
+
+	public function testBadPotionDoesNotUnlockBelow15(): void
+	{
+		$context = new ContextPreparator(['achievement-conditions' => [['category' => 'potion', 'value' => HeroPowers::$BAD_POTION_THRESHOLD - 1]]]);
+		new AchievementChecker()->checkDanSolveAchievements();
+		$this->assertAchievementNotUnlocked(Achievement::BAD_POTION);
 	}
 }

--- a/tests/TestCase/Controller/Component/PlayResultProcessorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PlayResultProcessorComponentTest.php
@@ -642,4 +642,78 @@ class PlayResultProcessorComponentTest extends TestCaseWithAuth
 				"No unsolved attempt should be created for status '$status'");
 		}
 	}
+
+	/**
+	 * Verifies the Bad Potion counter integration: when a user has potion active
+	 * (used_potion=0, level >= 50, exactly at max health) and the previous
+	 * problem was failed, the achievement_condition.value counter for
+	 * category='potion' increments because chance = 0 x 0.5% = 0%.
+	 */
+	public function testPotionConditionIncrementsOnPreviousFail(): void
+	{
+		$maxHealth = Util::getHealthBasedOnLevel(50);
+		$context = new ContextPreparator([
+			'user' => [
+				'level' => 50,
+				'used_potion' => 0,
+				'damage' => $maxHealth,
+			],
+			'tsumego' => ['set_order' => 1]]);
+
+		$_COOKIE['hackedLoggedInUserID'] = $context->user['id'];
+		Auth::init();
+
+		// Signal that the PREVIOUS problem was failed (status 'F')
+		$_COOKIE['previousTsumegoBuffer'] = 'F';
+		$_COOKIE['previousTsumegoID'] = '99999999';
+
+		// damage == maxHealth so excessDeaths == 0, chance == 0%, counter always increments
+
+		// Load a tsumego page -- Play.php reads the buffer and increments the condition
+		$this->testAction(self::getUrlFromPage('tsumego', $context));
+
+		$condition = ClassRegistry::init('AchievementCondition')->find('first', [
+			'conditions' => [
+				'user_id' => $context->user['id'],
+				'category' => 'potion',
+			],
+		]);
+		$this->assertNotNull($condition, 'potion achievement_condition must be created');
+		$this->assertSame(1, (int) $condition['AchievementCondition']['value'],
+			'potion condition value must increment to 1 on first miss');
+	}
+
+	/**
+	 * Verifies the potion trigger path: when damage far exceeds max health,
+	 * the progressive chance reaches 100% and potion always heals.
+	 * Also verifies the banner renders in the view output.
+	 */
+	public function testPotionTriggersAndConsumesOnPreviousFail(): void
+	{
+		$maxHealth = Util::getHealthBasedOnLevel(50);
+		$context = new ContextPreparator([
+			'user' => [
+				'level' => 50,
+				'used_potion' => 0,
+				'damage' => $maxHealth + 200,
+			],
+			'tsumego' => ['set_order' => 1]]);
+
+		$_COOKIE['hackedLoggedInUserID'] = $context->user['id'];
+		Auth::init();
+
+		$_COOKIE['previousTsumegoBuffer'] = 'F';
+		$_COOKIE['previousTsumegoID'] = '99999999';
+
+		// excessDeaths = 200, chance = min(200 × 0.5, 100) = 100%
+		$body = $this->testAction(self::getUrlFromPage('tsumego', $context), ['return' => 'contents']);
+
+		$user = $context->reloadUser();
+		$this->assertSame(1, (int) $user['used_potion'],
+			'used_potion must be set to 1 when potion triggers (consumed for the day)');
+		$this->assertSame(0, (int) $user['damage'],
+			'damage must be cleared to 0 when potion heals');
+
+		$this->assertStringContainsString('id="potionAlerts"', $body);
+	}
 }


### PR DESCRIPTION
https://tsumego.com/forums/viewtopic.php?t=142

Bad Potion achievement didn't work, it used non-existing column 'potion' as counter. The cron reset wasn't resetting potion hero power and I couldn't find the implementation for it anywhere.

in the original code the potion also restored rejuvenation