### PR TITLE
fix: retry flaky browser tests, simplify Browser, clean up ContextPreparator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
 		"tedivm/jshrink": "^1.8"
 	},
     "require-dev": {
-		"php-webdriver/webdriver": "^1.15",
+		"bshaffer/phpunit-retry-annotations": "^0.3.0",
 		"friendsofphp/php-cs-fixer": "^3.89",
+		"php-webdriver/webdriver": "^1.15",
 		"phpstan/phpstan": "^2.1",
 		"phpunit/php-code-coverage": "^9.2",
 		"phpunit/phpcov": "^8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6293afb6d84f5465619685fd5692812",
+    "content-hash": "dc1ef9df9dcda113da6dae5cc0f17301",
     "packages": [
         {
             "name": "cakephp/chronos",
@@ -2115,6 +2115,57 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "bshaffer/phpunit-retry-annotations",
+            "version": "v0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bshaffer/phpunit-retry-annotations.git",
+                "reference": "b53a1ee5564433a94b7034d75c5b9f7c81dac64f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bshaffer/phpunit-retry-annotations/zipball/b53a1ee5564433a94b7034d75c5b9f7c81dac64f",
+                "reference": "b53a1ee5564433a94b7034d75c5b9f7c81dac64f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0",
+                "phpunit/phpunit": "^7.1|^8.0|^9.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPUnitRetry\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Shaffer",
+                    "email": "bshafs@gmail.com",
+                    "homepage": "https://brentertainment.com"
+                }
+            ],
+            "description": "Traits for retrying test methods and classes in PHPUnit",
+            "homepage": "https://github.com/bshaffer/phpunit-retry",
+            "keywords": [
+                "phpunit",
+                "retry",
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/bshaffer/phpunit-retry-annotations/issues",
+                "source": "https://github.com/bshaffer/phpunit-retry-annotations/tree/v0.3"
+            },
+            "time": "2022-07-18T23:39:59+00:00"
+        },
         {
             "name": "clue/ndjson-react",
             "version": "v1.3.0",
@@ -5989,12 +6040,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/tests/Browser.php
+++ b/tests/Browser.php
@@ -52,6 +52,15 @@ class Browser
 			$firefoxOptions->setPreference('security.ssl.errorReporting.enabled', false);
 			$firefoxOptions->setPreference('security.remote_settings.crlite_filters.enabled', false);
 			$firefoxOptions->setPreference('security.OCSP.require', false);
+			// Stability: disable features that cause issues in headless Docker
+			$firefoxOptions->setPreference('dom.disable_beforeunload', true);
+			$firefoxOptions->setPreference('dom.ipc.reportProcessHangs', false);
+			$firefoxOptions->setPreference('browser.safebrowsing.enabled', false);
+			$firefoxOptions->setPreference('browser.safebrowsing.malware.enabled', false);
+			$firefoxOptions->setPreference('datareporting.healthreport.uploadEnabled', false);
+			$firefoxOptions->setPreference('app.normandy.enabled', false);
+			$firefoxOptions->setPreference('app.shield.optoutstudies.enabled', false);
+			$firefoxOptions->setPreference('extensions.getAddons.cache.enabled', false);
 
 			$desiredCapabilities = DesiredCapabilities::firefox();
 			$desiredCapabilities->setCapability('acceptInsecureCerts', true);
@@ -60,7 +69,45 @@ class Browser
 
 		try
 		{
-			$this->driver = RemoteWebDriver::create($serverUrl, $desiredCapabilities, 10000, 30000);
+			// Wait for Selenium to be ready before attempting session creation.
+			// Docker Selenium containers can reject /session requests for a few
+			// seconds after startup or after a previous session ends.
+			$statusUrl = rtrim($serverUrl, '/') . '/status';
+			for ($i = 0; $i < 10; $i++)
+			{
+				$ch = curl_init($statusUrl);
+				curl_setopt_array($ch, [
+					CURLOPT_RETURNTRANSFER => true,
+					CURLOPT_TIMEOUT => 2,
+					CURLOPT_CONNECTTIMEOUT => 2,
+				]);
+				$response = curl_exec($ch);
+				curl_close($ch);
+				if ($response !== false)
+				{
+					$data = json_decode($response, true);
+					if (!empty($data['value']['ready']))
+						break;
+				}
+				if ($i === 9)
+					throw new \Exception("Selenium not ready after 10 attempts at $statusUrl");
+				sleep(2);
+			}
+
+			// Retry: Docker Selenium can be slow to create sessions
+			for ($i = 0; $i < 3; $i++)
+			{
+				try
+				{
+					$this->driver = RemoteWebDriver::create($serverUrl, $desiredCapabilities, 30000, 60000);
+					break;
+				}
+				catch (\Exception $e)
+				{
+					if ($i === 2) throw $e;
+					sleep(2);
+				}
+			}
 
 			$this->driver->manage()->timeouts()->pageLoadTimeout(30);
 
@@ -152,10 +199,24 @@ class Browser
 				$this->driver->manage()->addCookie(['name' => "disable-achievements", 'value' => "true"]);
 		}
 
-		// Strip leading slash from $url to avoid double slashes when concatenating
 		$url = ltrim($url, '/');
 		$this->driver->manage()->timeouts()->pageLoadTimeout(60);
-		$this->driver->get(Util::getMyAddress() . '/' . $url);
+
+		// Retry once on timeout — refreshes session if Selenium is slow
+		for ($i = 0; $i < 2; $i++)
+		{
+			try
+			{
+				$this->driver->get(Util::getMyAddress() . '/' . $url);
+				break;
+			}
+			catch (\Facebook\WebDriver\Exception\TimeoutException $e)
+			{
+				if ($i === 1) throw $e;
+				self::shutdown();
+				self::$browser = new Browser();
+			}
+		}
 		$this->assertNoErrors();
 	}
 
@@ -164,7 +225,20 @@ class Browser
 	{
 		$url = ltrim($url, '/');
 		$this->driver->manage()->timeouts()->pageLoadTimeout(60);
-		$this->driver->get(Util::getMyAddress() . '/' . $url);
+		for ($i = 0; $i < 2; $i++)
+		{
+			try
+			{
+				$this->driver->get(Util::getMyAddress() . '/' . $url);
+				break;
+			}
+			catch (\Facebook\WebDriver\Exception\TimeoutException $e)
+			{
+				if ($i === 1) throw $e;
+				self::shutdown();
+				self::$browser = new Browser();
+			}
+		}
 		$this->assertNoErrors();
 	}
 
@@ -217,7 +291,7 @@ class Browser
 		new WebDriverWait($this->driver, 5, 500)->until(function () { return $this->idExists('commentBox'); });
 	}
 
-	public function waitUntilCssSelectorExists(string $selector, int $timeout = 5): void
+	public function waitUntilCssSelectorExists(string $selector, int $timeout = 10): void
 	{
 		new WebDriverWait($this->driver, $timeout, 500)->until(
 			function () use ($selector) {
@@ -227,7 +301,7 @@ class Browser
 		);
 	}
 
-	public function waitUntilCssSelectorExistsWithText(string $selector, $text, int $timeout = 5): void
+	public function waitUntilCssSelectorExistsWithText(string $selector, $text, int $timeout = 10): void
 	{
 		new WebDriverWait($this->driver, $timeout, 500)->until(
 			function () use ($selector, $text) {
@@ -237,7 +311,7 @@ class Browser
 		);
 	}
 
-	public function waitUntilCssSelectorDisplayed(string $selector, int $timeout = 5): void
+	public function waitUntilCssSelectorDisplayed(string $selector, int $timeout = 10): void
 	{
 		new WebDriverWait($this->driver, $timeout, 500)->until(
 			function () use ($selector) {
@@ -247,7 +321,7 @@ class Browser
 		);
 	}
 
-	public function waitUntilCssSelectorDoesntExist(string $selector, int $timeout = 5): void
+	public function waitUntilCssSelectorDoesntExist(string $selector, int $timeout = 10): void
 	{
 		new WebDriverWait($this->driver, $timeout, 500)->until(
 			function () use ($selector) {
@@ -264,7 +338,7 @@ class Browser
 	 * @param string[] $selectors CSS selectors to wait for (at least one must exist)
 	 * @param int $timeout Timeout in seconds
 	 */
-	public function waitUntilAnyCssSelectorExists(array $selectors, int $timeout = 5): void
+	public function waitUntilAnyCssSelectorExists(array $selectors, int $timeout = 10): void
 	{
 		new WebDriverWait($this->driver, $timeout, 500)->until(
 			function () use ($selectors) {
@@ -372,24 +446,29 @@ class Browser
 		return false;
 	}
 
-	public static function instance()
+	private static function recover(): void
 	{
-		if (self::$browser == null)
-			self::$browser = new Browser();
-
-		// Recover from crashed/disconnected browser session
+		if (!self::$browser)
+			return;
 		try
 		{
 			self::$browser->driver->getCurrentURL();
 		}
 		catch (\Facebook\WebDriver\Exception\InvalidSessionIdException $e)
 		{
-			self::$browser = new Browser();
+			self::$browser = null;
 		}
 		catch (\Facebook\WebDriver\Exception\Internal\WebDriverCurlException $e)
 		{
-			self::$browser = new Browser();
+			self::$browser = null;
 		}
+	}
+
+	public static function instance()
+	{
+		self::recover();
+		if (self::$browser == null)
+			self::$browser = new Browser();
 
 		// Dismiss any lingering alerts from previous tests
 		try
@@ -556,7 +635,7 @@ class Browser
 	 * @param int $timeout Maximum wait time in seconds (default 5)
 	 * @return bool True if title contains expected text
 	 */
-	public function titleContains(string $expectedTitle, int $timeout = 5): bool
+	public function titleContains(string $expectedTitle, int $timeout = 10): bool
 	{
 		return $this->waitUntil(function ($driver) use ($expectedTitle) {
 			return str_contains($driver->getTitle(), $expectedTitle);
@@ -569,7 +648,7 @@ class Browser
 	 * @param int $timeout Maximum wait time in seconds (default 5)
 	 * @return \Facebook\WebDriver\Remote\RemoteWebElement
 	 */
-	public function byId(string $id, int $timeout = 5)
+	public function byId(string $id, int $timeout = 10)
 	{
 		return $this->waitUntil(function ($driver) use ($id) {
 			return $driver->findElement(WebDriverBy::id($id));
@@ -582,7 +661,7 @@ class Browser
 	 * @param int $timeout Maximum wait time in seconds (default 5)
 	 * @return \Facebook\WebDriver\Remote\RemoteWebElement
 	 */
-	public function byCssSelector(string $selector, int $timeout = 5)
+	public function byCssSelector(string $selector, int $timeout = 10)
 	{
 		return $this->waitUntil(function ($driver) use ($selector) {
 			return $driver->findElement(WebDriverBy::cssSelector($selector));
@@ -595,7 +674,7 @@ class Browser
 	 * @param int $timeout Maximum wait time in seconds
 	 * @return mixed The result of the condition function
 	 */
-	private function waitUntil(callable $condition, int $timeout = 5)
+	private function waitUntil(callable $condition, int $timeout = 10)
 	{
 		$wait = new WebDriverWait($this->driver, $timeout, 500);
 		return $wait->until(function ($driver) use ($condition) {

--- a/tests/Browser.php
+++ b/tests/Browser.php
@@ -72,6 +72,9 @@ class Browser
 			// Wait for Selenium to be ready before attempting session creation.
 			// Docker Selenium containers can reject /session requests for a few
 			// seconds after startup or after a previous session ends.
+			//
+			// Throws \Exception (not WebDriverException): after 20s of waiting
+			// Selenium is genuinely down, retrying tests would be pointless.
 			$statusUrl = rtrim($serverUrl, '/') . '/status';
 			for ($i = 0; $i < 10; $i++)
 			{
@@ -94,20 +97,7 @@ class Browser
 				sleep(2);
 			}
 
-			// Retry: Docker Selenium can be slow to create sessions
-			for ($i = 0; $i < 3; $i++)
-			{
-				try
-				{
-					$this->driver = RemoteWebDriver::create($serverUrl, $desiredCapabilities, 30000, 60000);
-					break;
-				}
-				catch (\Exception $e)
-				{
-					if ($i === 2) throw $e;
-					sleep(2);
-				}
-			}
+			$this->driver = RemoteWebDriver::create($serverUrl, $desiredCapabilities, 30000, 60000);
 
 			$this->driver->manage()->timeouts()->pageLoadTimeout(30);
 
@@ -201,22 +191,7 @@ class Browser
 
 		$url = ltrim($url, '/');
 		$this->driver->manage()->timeouts()->pageLoadTimeout(60);
-
-		// Retry once on timeout — refreshes session if Selenium is slow
-		for ($i = 0; $i < 2; $i++)
-		{
-			try
-			{
-				$this->driver->get(Util::getMyAddress() . '/' . $url);
-				break;
-			}
-			catch (\Facebook\WebDriver\Exception\TimeoutException $e)
-			{
-				if ($i === 1) throw $e;
-				self::shutdown();
-				self::$browser = new Browser();
-			}
-		}
+		$this->driver->get(Util::getMyAddress() . '/' . $url);
 		$this->assertNoErrors();
 	}
 
@@ -225,20 +200,7 @@ class Browser
 	{
 		$url = ltrim($url, '/');
 		$this->driver->manage()->timeouts()->pageLoadTimeout(60);
-		for ($i = 0; $i < 2; $i++)
-		{
-			try
-			{
-				$this->driver->get(Util::getMyAddress() . '/' . $url);
-				break;
-			}
-			catch (\Facebook\WebDriver\Exception\TimeoutException $e)
-			{
-				if ($i === 1) throw $e;
-				self::shutdown();
-				self::$browser = new Browser();
-			}
-		}
+		$this->driver->get(Util::getMyAddress() . '/' . $url);
 		$this->assertNoErrors();
 	}
 

--- a/tests/ContextPreparator.php
+++ b/tests/ContextPreparator.php
@@ -114,8 +114,6 @@ class ContextPreparator
 			throw new Exception("Failed to save user: " . print_r($Model->validationErrors, true));
 		$user = ClassRegistry::init('User')->find('first', ['conditions' => ['name' => $user['name']]])['User'];
 
-		ClassRegistry::init('UserContribution')->deleteAll(['user_id' => $this->user['id']]);
-
 		if (isset($userInput['query'])
 			|| isset($userInput['filtered_sets'])
 			|| isset($userInput['filtered_topics'])
@@ -383,7 +381,6 @@ class ContextPreparator
 	{
 		if (!$setsInput)
 			return;
-		ClassRegistry::init('SetConnection')->deleteAll(['tsumego_id' => $tsumego['id']]);
 		$this->tsumegoSets = [];
 		foreach ($setsInput as $tsumegoSet)
 			$this->prepareTsumegoSet($tsumegoSet, $tsumego);
@@ -417,7 +414,6 @@ class ContextPreparator
 		if (!$tagsInput)
 			return;
 
-		ClassRegistry::init('TagConnection')->deleteAll(['tsumego_id' => $tsumego['id']]);
 		foreach ($tagsInput as $tagInput)
 		{
 			$tag = $this->getOrCreateTag([
@@ -509,9 +505,12 @@ class ContextPreparator
 
 	private function checkSetClear(int $setID): void
 	{
-		if ($this->setsCleared[$setID])
+		if (isset($this->setsCleared[$setID]))
 			return;
-		ClassRegistry::init('SetConnection')->deleteAll(['set_id' => $setID]);
+		$pdo = ClassRegistry::init('User')->getDataSource()->getConnection();
+		$pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+		$pdo->exec("DELETE FROM `set_connection` WHERE `set_id` = " . intval($setID));
+		$pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
 		$this->setsCleared[$setID] = true;
 	}
 
@@ -584,8 +583,6 @@ class ContextPreparator
 		if (!$timeModeSessions)
 			return;
 
-		ClassRegistry::init('TimeModeSession')->deleteAll(['1 = 1']);
-
 		foreach ($timeModeSessions as $timeModeSessionInput)
 		{
 			$timeModeSession = [];
@@ -601,9 +598,9 @@ class ContextPreparator
 			$timeModeSessionModel->save($timeModeSession);
 			$newSessionId = $timeModeSessionModel->id;
 			$savedSession = $timeModeSessionModel->data['TimeModeSession'];
-			$savedSession['id'] = $newSessionId; // Ensure ID is present
+			$savedSession['id'] = $newSessionId;
 			$this->timeModeSessions [] = $savedSession;
-			foreach ($timeModeSessionInput['attempts'] as $attemptInput)
+			foreach (($timeModeSessionInput['attempts'] ?? []) as $attemptInput)
 				$this->prepareTimeModeAttempts($attemptInput, $newSessionId);
 		}
 	}
@@ -767,8 +764,11 @@ class ContextPreparator
 
 		$adminActivityType = ClassRegistry::init('AdminActivityType');
 
-		// Clear existing entries and repopulate with correct IDs
-		$adminActivityType->deleteAll(['1 = 1']);
+		// Clear and repopulate with correct IDs (this table is not in the constructor wipe)
+		$pdo = ClassRegistry::init('User')->getDataSource()->getConnection();
+		$pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+		$pdo->exec('DELETE FROM `admin_activity_type`');
+		$pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
 
 		foreach ($types as $id => $name)
 		{

--- a/tests/ContextPreparator.php
+++ b/tests/ContextPreparator.php
@@ -6,41 +6,22 @@ class ContextPreparator
 {
 	public function __construct(?array $options = [])
 	{
-		// Disable FK checks via raw PDO to avoid CakePHP query()/execute() pipeline flakiness
+		// Delete all test data via raw PDO so FK check disable is guaranteed on the same connection
 		/** @var DboSource $db */
 		$db = ClassRegistry::init('User')->getDataSource();
-		$db->getConnection()->exec('SET FOREIGN_KEY_CHECKS = 0');
-
-		ClassRegistry::init('TagConnection')->deleteAll(['1 = 1'], false);      // FK to: user, tag
-		ClassRegistry::init('Tag')->deleteAll(['1 = 1'], false);                // FK to: user
-		ClassRegistry::init('Favorite')->deleteAll(['1 = 1'], false);           // FK to: user, tsumego
-		ClassRegistry::init('Schedule')->deleteAll(['1 = 1'], false);           // FK to: Tsumego, Set
-		ClassRegistry::init('ProgressDeletion')->deleteAll(['1 = 1'], false);   // FK to: User, Set
-		ClassRegistry::init('DayRecord')->deleteAll(['1 = 1'], false);          // FK to: User
-		ClassRegistry::init('Sgf')->deleteAll(['1 = 1'], false);                // FK to: User, Tsumego
-		ClassRegistry::init('TimeModeAttempt')->deleteAll(['1 = 1'], false);    // FK to: TimeModeSession
-		ClassRegistry::init('TimeModeSession')->deleteAll(['1 = 1'], false);    // FK to: User, TimeModeRank
-		ClassRegistry::init('TsumegoComment')->deleteAll(['1 = 1'], false);     // FK to: User
-		ClassRegistry::init('TsumegoIssue')->deleteAll(['1 = 1'], false);       // FK to: User
-		ClassRegistry::init('AdminActivity')->deleteAll(['1 = 1'], false);      // FK to: User, Tsumego, Set
-		ClassRegistry::init('AchievementCondition')->deleteAll(['1 = 1'], false);  // FK to: User, Set
-		ClassRegistry::init('AchievementStatus')->deleteAll(['1 = 1'], false);  // FK to: User, Achievement
-		ClassRegistry::init('SetConnection')->deleteAll(['1 = 1'], false);      // FK to: Tsumego, Set
-		ClassRegistry::init('TsumegoAttempt')->deleteAll(['1 = 1'], false);     // FK to: User, Tsumego
-		ClassRegistry::init('TsumegoStatus')->deleteAll(['1 = 1'], false);      // FK to: User, Tsumego
-		ClassRegistry::init('UserContribution')->deleteAll(['1 = 1'], false);   // Parent table
-		ClassRegistry::init('Signature')->deleteAll(['1 = 1'], false);          // Parent table
-		ClassRegistry::init('TsumegoVariant')->deleteAll(['1 = 1'], false);     // Parent table
-		ClassRegistry::init('Reject')->deleteAll(['1 = 1'], false);             // Parent table
-		ClassRegistry::init('PublishDate')->deleteAll(['1 = 1'], false);        // Parent table
-		ClassRegistry::init('User')->deleteAll(['1 = 1'], false);               // Parent table
-		ClassRegistry::init('TimeModeRank')->deleteAll(['1 = 1'], false);       // Parent table
-		ClassRegistry::init('Tsumego')->deleteAll(['1 = 1'], false);            // Parent table
-		ClassRegistry::init('Set')->deleteAll(['1 = 1'], false);                // Parent table
-
-		/** @var DboSource $db */
-		$db = ClassRegistry::init('User')->getDataSource();
-		$db->getConnection()->exec('SET FOREIGN_KEY_CHECKS = 1');
+		$pdo = $db->getConnection();
+		$pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+		foreach ([
+			'tag_connection', 'tag', 'favorite', 'schedule', 'progress_deletion',
+			'day_record', 'sgf', 'time_mode_attempt', 'time_mode_session',
+			'tsumego_comment', 'tsumego_issue', 'admin_activity',
+			'achievement_condition', 'achievement_status', 'set_connection',
+			'tsumego_attempt', 'tsumego_status', 'user_contribution', 'signature',
+			'tsumego_variant', 'reject', 'publish_date', 'user', 'time_mode_rank',
+			'tsumego', 'set',
+		] as $table)
+			$pdo->exec("DELETE FROM `$table`");
+		$pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
 
 		if (!array_key_exists('user', $options) && !array_key_exists('other-users', $options))
 			$this->prepareThisUser(['name' => 'kovarex']);

--- a/tests/SuperglobalCleanup.php
+++ b/tests/SuperglobalCleanup.php
@@ -1,12 +1,11 @@
 <?php
 
 use PHPUnit\Runner\BeforeTestHook;
-use PHPUnit\Runner\AfterTestHook;
 
 /**
- * Clears PHP superglobals before and after each test to prevent state bleeding.
+ * Clears PHP superglobals before each test to prevent state bleeding.
  */
-final class SuperglobalCleanup implements BeforeTestHook, AfterTestHook
+final class SuperglobalCleanup implements BeforeTestHook
 {
 	private static function cleanup(): void
 	{
@@ -16,8 +15,6 @@ final class SuperglobalCleanup implements BeforeTestHook, AfterTestHook
 		$_REQUEST = [];
 		$_COOKIE = [];
 		$_SESSION = [];
-		if (session_status() === PHP_SESSION_ACTIVE)
-			session_destroy();
 		Auth::logout();
 		JwtAuth::clearCache();
 		CookieFlash::clearCache();
@@ -25,11 +22,6 @@ final class SuperglobalCleanup implements BeforeTestHook, AfterTestHook
 	}
 
 	public function executeBeforeTest(string $test): void
-	{
-		self::cleanup();
-	}
-
-	public function executeAfterTest(string $test, float $time): void
 	{
 		self::cleanup();
 	}

--- a/tests/TestCase/AccountWidgetTest.php
+++ b/tests/TestCase/AccountWidgetTest.php
@@ -1,7 +1,14 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
+
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class AccountWidgetTest extends ControllerTestCase
 {
+	use RetryTrait;
 	// by default we show level
 	public function testShowLevelInAccountWidget()
 	{

--- a/tests/TestCase/Achievement/AchievementTestCase.php
+++ b/tests/TestCase/Achievement/AchievementTestCase.php
@@ -1,8 +1,17 @@
 <?php
 
-// Base class for all achievement tests
+use PHPUnitRetry\RetryTrait;
+
+/**
+ * Base class for all achievement tests.
+ *
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 abstract class AchievementTestCase extends ControllerTestCase
 {
+	use RetryTrait;
+
 	protected function assertAchievementUnlockedWhen($when, $achievementId, $message = null)
 	{
 		if ($when)

--- a/tests/TestCase/Achievement/Unlock/TimeModeAchievementTest.php
+++ b/tests/TestCase/Achievement/Unlock/TimeModeAchievementTest.php
@@ -87,16 +87,19 @@ class TimeModeAchievementTest extends AchievementTestCase
 		{
 			// Test Slow mode
 			$context = new ContextPreparator([
+				'tsumego' => 1,
 				'time-mode-ranks' => [$rank],
 				'time-mode-sessions' => [[
 					'category' => TimeModeUtil::$CATEGORY_SLOW_SPEED,
 					'status' => TimeModeUtil::$SESSION_STATUS_SOLVED,
-					'rank' => $rank]]]);
+					'rank' => $rank,
+					'attempts' => []]]]);
 			new AchievementChecker()->checkTimeModeAchievements();
 			$this->assertAchievementUnlocked($achievementIds[$index], "Slow $rank achievement");
 
 			// Test Fast mode
 			$context = new ContextPreparator([
+				'tsumego' => 1,
 				'time-mode-ranks' => [$rank],
 				'time-mode-sessions' => [[
 					'category' => TimeModeUtil::$CATEGORY_FAST_SPEED,
@@ -108,11 +111,13 @@ class TimeModeAchievementTest extends AchievementTestCase
 
 			// Test Blitz mode
 			$context = new ContextPreparator([
+				'tsumego' => 1,
 				'time-mode-ranks' => [$rank],
 				'time-mode-sessions' => [[
 					'category' => TimeModeUtil::$CATEGORY_BLITZ,
 					'status' => TimeModeUtil::$SESSION_STATUS_SOLVED,
-					'rank' => $rank]]]);
+					'rank' => $rank,
+					'attempts' => []]]]);
 			new AchievementChecker()->checkTimeModeAchievements();
 			$this->assertAchievementUnlocked(Achievement::TIME_MODE_APPRENTICE_BLITZ + $index, "Blitz $rank achievement");
 		}

--- a/tests/TestCase/AssetBundlingTest.php
+++ b/tests/TestCase/AssetBundlingTest.php
@@ -1,12 +1,16 @@
 <?php
 
 use Facebook\WebDriver\WebDriverBy;
+use PHPUnitRetry\RetryTrait;
 
 /**
  * AssetBundlingTest
  *
  * Verifies that CSS and JS assets are properly bundled via Vite,
  * that styles are applied, and that JavaScript functions are loaded and working.
+ *
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
  *
  * @group disabled
  *
@@ -15,6 +19,7 @@ use Facebook\WebDriver\WebDriverBy;
  */
 class AssetBundlingTest extends CakeTestCase
 {
+	use RetryTrait;
 	/**
 	 * Test that CSS bundles are loaded and individual files are NOT loaded
 	 */

--- a/tests/TestCase/BesogoTest.php
+++ b/tests/TestCase/BesogoTest.php
@@ -1,7 +1,14 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
+
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class BesogoTest extends ControllerTestCase
 {
+	use RetryTrait;
 	public function testBesogoTests()
 	{
 		$browser = Browser::instance();

--- a/tests/TestCase/Controller/AdminStatsControllerTest.php
+++ b/tests/TestCase/Controller/AdminStatsControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Facebook\WebDriver\WebDriverBy;
+use PHPUnitRetry\RetryTrait;
 
 App::uses('AdminActivityLogger', 'Utility');
 App::uses('AdminActivityType', 'Model');
@@ -13,9 +14,13 @@ App::uses('AdminActivityType', 'Model');
  * - Tests filtering out non-admin SGF uploads
  * - Tests pagination with multiple sections (activity, proposals, tags, tagnames)
  * - Tests all 18 activity types display correctly with formatted messages
+ *
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
  */
 class AdminStatsControllerTest extends ControllerTestCase
 {
+	use RetryTrait;
 	/**
 	 * Test adminstats page displays in browser
 	 */

--- a/tests/TestCase/Controller/CommentsControllerTest.php
+++ b/tests/TestCase/Controller/CommentsControllerTest.php
@@ -2,11 +2,18 @@
 
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverExpectedCondition;
+use PHPUnitRetry\RetryTrait;
 
 App::uses('TsumegoIssue', 'Model');
 
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class CommentsControllerTest extends ControllerTestCase
 {
+	use RetryTrait;
+
 	public function testAddCommentToSolvedTsumego()
 	{
 		$browser = Browser::instance();

--- a/tests/TestCase/Controller/EditTsumegoTest.php
+++ b/tests/TestCase/Controller/EditTsumegoTest.php
@@ -1,9 +1,15 @@
 <?php
 
 use Facebook\WebDriver\WebDriverKeys;
+use PHPUnitRetry\RetryTrait;
 
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class EditTsumegoTest extends ControllerTestCase
 {
+	use RetryTrait;
 	public static function editTsumegoProvider(): array
 	{
 		return [

--- a/tests/TestCase/Controller/SetsControllerAdminTest.php
+++ b/tests/TestCase/Controller/SetsControllerAdminTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
+
 App::uses('ControllerTestCase', 'TestSuite');
 App::uses('Browser', 'TestSuite');
 App::uses('ContextPreparator', 'TestSuite');
@@ -7,10 +9,14 @@ App::uses('ContextPreparator', 'TestSuite');
 /**
  * Tests for SetsController admin functions (create set/tsumego)
  *
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ *
  * @group browser
  */
 class SetsControllerAdminTest extends ControllerTestCase
 {
+	use RetryTrait;
 	/**
 	 * Test SetsController::create() - creating new set with first tsumego
 	 */

--- a/tests/TestCase/Controller/SetsControllerTest.php
+++ b/tests/TestCase/Controller/SetsControllerTest.php
@@ -181,6 +181,7 @@ class SetsControllerTest extends TestCaseWithAuth
 
 	private function checkPlayTitle($browser, string $title)
 	{
+		$browser->waitUntilCssSelectorExists('#playTitle');
 		$collectionTopDivs = $browser->driver->findElements(WebDriverBy::cssSelector('#playTitle'));
 		$this->assertCount(1, $collectionTopDivs);
 		$this->assertTextStartsWith($title, $collectionTopDivs[0]->getText());

--- a/tests/TestCase/Controller/SetsViewStartButtonTest.php
+++ b/tests/TestCase/Controller/SetsViewStartButtonTest.php
@@ -1,15 +1,20 @@
 <?php
 
 use Facebook\WebDriver\WebDriverBy;
+use PHPUnitRetry\RetryTrait;
 
 /**
  * Tests the Start button on set view pages.
  *
  * This test verifies that clicking the Start button on /sets/view/{setId}
  * navigates to the FIRST UNSOLVED puzzle in the set (not just the first puzzle).
+ *
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
  */
 class SetsViewStartButtonTest extends ControllerTestCase
 {
+	use RetryTrait;
 	public function testStartButtonNavigatesToFirstUnsolvedPuzzle(): void
 	{
 		// when $statusToPick is 'W' (solved once more than a week ago)

--- a/tests/TestCase/Controller/SitesControllerTest.php
+++ b/tests/TestCase/Controller/SitesControllerTest.php
@@ -1,9 +1,16 @@
 <?php
 
 use Facebook\WebDriver\WebDriverBy;
+use PHPUnitRetry\RetryTrait;
 
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class SitesControllerTest extends ControllerTestCase
 {
+	use RetryTrait;
+
 	public function testIndex()
 	{
 		$browser = Browser::instance();

--- a/tests/TestCase/Controller/SmokeTest.php
+++ b/tests/TestCase/Controller/SmokeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
 use Selenium\Keys;
 
 App::uses('TimeModeUtil', 'Utility');
@@ -9,9 +10,13 @@ App::uses('TimeModeUtil', 'Utility');
  * - No JavaScript errors
  * - CSS is loaded properly
  * - Core functionality works
+ *
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
  */
 class SmokeTest extends ControllerTestCase
 {
+	use RetryTrait;
 	public function testAllMajorPagesLoadWithoutErrors()
 	{
 		// Create realistic production-like test data

--- a/tests/TestCase/Controller/TagTest.php
+++ b/tests/TestCase/Controller/TagTest.php
@@ -1,7 +1,15 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
+
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class TagTest extends ControllerTestCase
 {
+	use RetryTrait;
+
 	public function testAddTagConnection()
 	{
 		foreach ([false, true] as $isAdmin)

--- a/tests/TestCase/Controller/TestCaseWithAuth.php
+++ b/tests/TestCase/Controller/TestCaseWithAuth.php
@@ -2,9 +2,16 @@
 
 use DOM\HTMLDocument as DOMDocument;
 use Facebook\WebDriver\WebDriverBy;
+use PHPUnitRetry\RetryTrait;
 
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class TestCaseWithAuth extends ControllerTestCase
 {
+	use RetryTrait;
+
 	public function setUp(): void
 	{
 		parent::setUp();

--- a/tests/TestCase/Controller/TsumegoIssuesControllerTest.php
+++ b/tests/TestCase/Controller/TsumegoIssuesControllerTest.php
@@ -1,12 +1,20 @@
 <?php
 
 use Facebook\WebDriver\WebDriverBy;
+use PHPUnitRetry\RetryTrait;
 
 App::uses('TsumegoIssue', 'Model');
 
-// Tests for TsumegoIssuesController - specifically the global issues index page.
+/**
+ * Tests for TsumegoIssuesController - specifically the global issues index page.
+ *
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class TsumegoIssuesControllerTest extends ControllerTestCase
 {
+	use RetryTrait;
+
 	public function testIssuesIndexPageLoads()
 	{
 		$browser = Browser::instance();

--- a/tests/TestCase/Controller/UsersControllerTest.php
+++ b/tests/TestCase/Controller/UsersControllerTest.php
@@ -1,9 +1,16 @@
 <?php
 
 use Facebook\WebDriver\WebDriverBy;
+use PHPUnitRetry\RetryTrait;
 
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class UsersControllerTest extends ControllerTestCase
 {
+	use RetryTrait;
+
 	/**
 	 * Test that login redirects back to the page where user came from.
 	 */

--- a/tests/TestCase/Infrastructure/JavaScriptErrorTrackingTest.php
+++ b/tests/TestCase/Infrastructure/JavaScriptErrorTrackingTest.php
@@ -1,7 +1,15 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
+
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class JavaScriptErrorTrackingTest extends CakeTestCase
 {
+	use RetryTrait;
+
 	/* Verifies that JavaScript error tracking is enabled in test environment.
 	 * This test ensures debug mode is enabled so window.__jsErrors is initialized.
 	 * Without debug mode, ALL browser tests will be blind to JavaScript errors.

--- a/tests/TestCase/RatingModeTest.php
+++ b/tests/TestCase/RatingModeTest.php
@@ -2,9 +2,15 @@
 
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
+use PHPUnitRetry\RetryTrait;
 
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class RatingModeTest extends ControllerTestCase
 {
+	use RetryTrait;
 	public function testRatingMode()
 	{
 		$context = new ContextPreparator([

--- a/tests/TestCase/TsumegoMergeTest.php
+++ b/tests/TestCase/TsumegoMergeTest.php
@@ -1,7 +1,14 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
+
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class TsumegoMergeTest extends ControllerTestCase
 {
+	use RetryTrait;
 	public function testMergeTwoTsumegos()
 	{
 		foreach (['notAdmin', 'masterNotSpecified', 'slaveNotSpecified', 'slaveAndMasterAlreadyMarged', 'merge', 'mergeWithDoubleFavorite', 'masterWithoutStatus'] as $testCase)

--- a/tests/TestCase/Utility/BoardSelectorTest.php
+++ b/tests/TestCase/Utility/BoardSelectorTest.php
@@ -1,7 +1,15 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
+
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class BoardSelectorTest extends CakeTestCase
 {
+	use RetryTrait;
+
 	public function testChangeSelection()
 	{
 		$browser = Browser::instance();

--- a/tests/TestCase/Utility/CookieFlashBrowserTest.php
+++ b/tests/TestCase/Utility/CookieFlashBrowserTest.php
@@ -4,14 +4,19 @@ App::uses('Browser', '.');
 App::uses('CookieFlash', 'Utility');
 
 use Facebook\WebDriver\WebDriverBy;
+use PHPUnitRetry\RetryTrait;
 
 /**
  * Browser tests for CookieFlash functionality.
  *
  * Tests that flash messages render correctly in the browser and auto-clear.
+ *
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
  */
 class CookieFlashBrowserTest extends CakeTestCase
 {
+	use RetryTrait;
 	/**
 	 * Test that flash message appears after failed login attempt
 	 */

--- a/tests/TestCase/Utility/SecondarySgfDataFillingTest.php
+++ b/tests/TestCase/Utility/SecondarySgfDataFillingTest.php
@@ -1,7 +1,15 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
+
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class SecondarySgfDataFillingTest extends CakeTestCase
 {
+	use RetryTrait;
+
 	public function testFillFirstAndCorrectMoves()
 	{
 		$browser = Browser::instance();

--- a/tests/TestCase/Utility/SimilarSearchLogicTest.php
+++ b/tests/TestCase/Utility/SimilarSearchLogicTest.php
@@ -1,7 +1,15 @@
 <?php
 
+use PHPUnitRetry\RetryTrait;
+
+/**
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
+ */
 class SimilarSearchLogicTest extends CakeTestCase
 {
+	use RetryTrait;
+
 	public function testSimilarSearchSameProblem()
 	{
 		$browser = Browser::instance();

--- a/tests/TestCase/View/DarkLightModeTest.php
+++ b/tests/TestCase/View/DarkLightModeTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Facebook\WebDriver\WebDriverBy;
+use PHPUnitRetry\RetryTrait;
 
 /**
  * Tests for dark/light mode theming functionality.
@@ -9,9 +10,13 @@ use Facebook\WebDriver\WebDriverBy;
  * - HTML data-theme attribute is correctly set based on cookie/preference
  * - JavaScript toggle properly switches data-theme attribute
  * - CSS custom properties are correctly applied for each mode
+ *
+ * @retryAttempts 2
+ * @retryIfException Facebook\WebDriver\Exception\WebDriverException
  */
 class DarkLightModeTest extends ControllerTestCase
 {
+	use RetryTrait;
 	/**
 	 * Test that html has data-theme="light" by default
 	 */


### PR DESCRIPTION
It seems that it's inevitable that Browser instance times out because of selenium crash due to it running inside wsl. The retry method I initially used could recreate browser instance in the middle of the test - which would mean it wouldn't have proper state like js vars, cookies, etc. 

retry annotation makes all browser test retry 3 times if they fail on some suspicious error (WebDriverException)

local run

=== RUN 1 ===
  PASS OK (540 tests, 4164 assertions)
=== RUN 2 ===
  PASS OK (540 tests, 4164 assertions)
=== RUN 3 ===
  PASS OK (540 tests, 4164 assertions)
=== RUN 4 ===
  PASS OK (540 tests, 4164 assertions)
=== RUN 5 ===
  PASS OK (540 tests, 4164 assertions)
=== RUN 6 ===
  PASS OK (540 tests, 4164 assertions)
=== RUN 7 ===
  PASS OK (540 tests, 4164 assertions)
=== RUN 8 ===
  PASS OK (540 tests, 4164 assertions)
=== RUN 9 ===
  PASS OK (540 tests, 4164 assertions)
=== RUN 10 ===
  PASS OK (540 tests, 4164 assertions)