### PR TITLE
fix: stop timer when not on puzzle (forum#149)

### DIFF
--- a/src/Controller/Component/PlayResultProcessorComponent.php
+++ b/src/Controller/Component/PlayResultProcessorComponent.php
@@ -202,7 +202,7 @@ class PlayResultProcessorComponent extends Component
 
 		$tsumegoAttempt['TsumegoAttempt']['user_rating'] = Auth::getUser()['rating'];
 		$tsumegoAttempt['TsumegoAttempt']['gain'] = $result['xp-gained'] ?: 0;
-		$tsumegoAttempt['TsumegoAttempt']['seconds'] += Decoder::decodeSeconds($previousTsumego);
+		$tsumegoAttempt['TsumegoAttempt']['seconds'] = Decoder::decodeSeconds($previousTsumego);
 		$tsumegoAttempt['TsumegoAttempt']['solved'] = $result['solved'];
 		$tsumegoAttempt['TsumegoAttempt']['tsumego_rating'] = $previousTsumego['Tsumego']['rating'];
 		$tsumegoAttempt['TsumegoAttempt']['misplays'] += $result['misplays'] ?: 0;

--- a/tests/TestCase/Controller/Component/PlayResultProcessorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PlayResultProcessorComponentTest.php
@@ -43,6 +43,14 @@ class PlayResultProcessorComponentTest extends TestCaseWithAuth
 		$this->assertEmpty($_COOKIE['misplays']); // should be processed and cleared
 	}
 
+	private function performSolveWithSeconds(ContextPreparator &$context, $page, float $seconds): void
+	{
+		$_COOKIE['mode'] = '1';
+		$_COOKIE['solvedCheck'] = Util::encrypt($context->tsumegos[0]['id'] . '-' . time());
+		$_COOKIE['secondsCheck'] = $seconds * 100 * $context->tsumegos[0]['id'] * 79;
+		$this->performVisit($context, $page);
+	}
+
 	private function performSolveWithMisplays(ContextPreparator &$context, $page, int $misplays = 1): void
 	{
 		$_COOKIE['mode'] = '1';
@@ -640,6 +648,52 @@ class PlayResultProcessorComponentTest extends TestCaseWithAuth
 			]);
 			$this->assertCount(0, $unsolvedAttempts,
 				"No unsolved attempt should be created for status '$status'");
+		}
+	}
+
+	public function testSecondsReflectSolveTime(): void
+	{
+		foreach ($this->PAGES as $page)
+		{
+			$context = new ContextPreparator(['tsumego' => ['set_order' => 1]]);
+			$this->performSolveWithSeconds($context, $page, 20.0);
+
+			$attempts = ClassRegistry::init('TsumegoAttempt')->find('all', [
+				'conditions' => [
+					'tsumego_id' => $context->tsumegos[0]['id'],
+					'user_id' => $context->user['id'],
+				],
+			]);
+			$this->assertCount(1, $attempts);
+			$this->assertEqualsWithDelta(20.0, (float) $attempts[0]['TsumegoAttempt']['seconds'], 0.01);
+		}
+	}
+
+	public function testSecondsReflectLatestSolveTime(): void
+	{
+		foreach ($this->PAGES as $page)
+		{
+			$context = new ContextPreparator([
+				'tsumego' => [
+					'attempt' => ['solved' => false, 'seconds' => 1000, 'misplays' => 0],
+					'set_order' => 1,
+				],
+			]);
+
+			$_COOKIE['mode'] = '1';
+			$_COOKIE['solvedCheck'] = Util::encrypt($context->tsumegos[0]['id'] . '-' . time());
+			$_COOKIE['secondsCheck'] = 5 * 100 * $context->tsumegos[0]['id'] * 79;
+
+			$this->performVisit($context, $page);
+
+			$attempts = ClassRegistry::init('TsumegoAttempt')->find('all', [
+				'conditions' => [
+					'tsumego_id' => $context->tsumegos[0]['id'],
+					'user_id' => $context->user['id'],
+				],
+			]);
+			$this->assertCount(1, $attempts);
+			$this->assertEqualsWithDelta(5.0, (float) $attempts[0]['TsumegoAttempt']['seconds'], 0.01);
 		}
 	}
 }


### PR DESCRIPTION
This will stop timer when not on page, unless you override it

<img width="1273" height="871" alt="image" src="https://github.com/user-attachments/assets/1a9b3237-76f3-442c-a7c5-7b81c2190ebc" />

<img width="353" height="94" alt="image" src="https://github.com/user-attachments/assets/7514f0aa-20dc-4a2b-b492-ef8f6cee009c" />


but perhaps the overlay is too annoying though -> perhaps blurring just puzzle?

only partial fix, rest of the fix is fix/ajax-result-submission