### PR TITLE
fix: remove max-height on board SVG to prevent squashed display (#234)

### DIFF
--- a/webroot/besogo/css/besogo.css
+++ b/webroot/besogo/css/besogo.css
@@ -38,7 +38,6 @@
     -ms-user-select: none;       /* Internet Explorer/Edge */
      user-select: none;
      
-    max-height: 70vh;
 }
 
 .besogo-panels {


### PR DESCRIPTION
@joschka-zimdars's solution to auto-rotate problems like https://tsumego.com/16783 will fix the original issue https://tsumego.com/forums/viewtopic.php?t=105
but at some point we should still do something that will make such problems appear smaller if user rotates it manually, which the max-width intended to fix, but the board then reacts incorrectly to the zoom
<img width="1166" height="1399" alt="Image" src="https://github.com/user-attachments/assets/f736f510-7688-4d77-b3ac-6770f923ecd6" />