### PR TITLE
fix: show recent achievements on landing page (fixes #103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ src/Config/asset_compress.local.ini
 
 /img/set_*
 /img/google/*.png
-webroot/mainPageAjax.txt
 webroot/userLogger.html
 webroot/cache_css/
 webroot/cache_js/
@@ -42,7 +41,6 @@ webroot/forums/store
 webroot/forums/config.php
 webroot/forums/vendor
 .idea/
-mainPageAjax.txt
 .local/
 
 # IDE and editor specific files #

--- a/app/home/RecentAchievements.tsx
+++ b/app/home/RecentAchievements.tsx
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { get } from '../shared/api';
+
+dayjs.extend(relativeTime);
+
+export interface RecentAchievement {
+	status_id: number;
+	id: number;
+	name: string;
+	image: string;
+	user_id: number;
+	user_name: string;
+	created: string;
+}
+
+interface RecentAchievementsProps {
+	initialAchievements: RecentAchievement[];
+}
+
+export function RecentAchievements({ initialAchievements }: RecentAchievementsProps)
+{
+	const query = useQuery<{ recentAchievements: RecentAchievement[] }>({
+		queryKey: ['recentAchievements'],
+		queryFn: () => get<{ recentAchievements: RecentAchievement[] }>('/sites/recentAchievements'),
+		initialData: { recentAchievements: initialAchievements },
+		refetchInterval: 60000,
+		refetchOnWindowFocus: false,
+		retry: false,
+	});
+
+	const achievements = query.data.recentAchievements;
+
+	return (
+		<div id="recent-achievement-stream">
+			{achievements.map(achievement => (
+				<div
+					key={achievement.status_id}
+					className="recent-achievement-row"
+				>
+					<div className="recent-achievement-icon">
+						<a href={`/achievements/view/${achievement.id}`}>
+							<img src={`/img/${achievement.image}.png`} width="34px" alt={achievement.name} />
+						</a>
+					</div>
+					<div className="recent-achievement-body">
+						<div className="recent-achievement-message">
+							<a className="recent-achievement-user-link" href={`/users/view/${achievement.user_id}`}>
+								{achievement.user_name}
+							</a> earned&nbsp;
+							<a className="recent-achievement-achievement-link" href={`/achievements/view/${achievement.id}`}>
+								<b>{achievement.name}</b>
+							</a>
+						</div>
+						<div className="recent-achievement-time">{dayjs(achievement.created).fromNow()}</div>
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from './shared/ErrorBoundary';
 import { AuthProvider } from './shared/AuthContext';
 import { CommentSection } from './comments/CommentSection';
 import { IssuesList } from './issues/IssuesList';
+import { RecentAchievements, type RecentAchievement } from './home/RecentAchievements';
 import { ApiError } from './shared/api';
 import type { CommentCounts } from './comments/commentTypes';
 
@@ -81,6 +82,26 @@ function initializeIssuesList()
 	);
 }
 
+function initializeRecentAchievements()
+{
+	const root = document.querySelector<HTMLElement>('[data-recent-achievements-root]');
+	if (!root)
+		return;
+
+	const initialAchievements = JSON.parse(root.dataset.initialAchievements || '[]') as RecentAchievement[];
+
+	const reactRoot = createRoot(root);
+	reactRoot.render(
+		<ErrorBoundary>
+			<AuthProvider userId={null} isAdmin={false}>
+				<QueryClientProvider client={globalQueryClient}>
+					<RecentAchievements initialAchievements={initialAchievements} />
+				</QueryClientProvider>
+			</AuthProvider>
+		</ErrorBoundary>
+	);
+}
+
 /**
  * Main initialization entry point
  */
@@ -88,6 +109,7 @@ function initializeApp()
 {
 	initializeComments();
 	initializeIssuesList();
+	initializeRecentAchievements();
 
 	// Expose React Query invalidation for Selenium testing
 	(window as any).__invalidateComments = () =>

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -29,29 +29,6 @@ class AppController extends Controller
 		return $dSets;
 	}
 
-	public static function getStartpage(): string
-	{
-		$result = '';
-		$latest = ClassRegistry::init('AchievementStatus')->find('all', ['limit' => 7, 'order' => 'created DESC']) ?: [];
-		$latestCount = count($latest);
-		for ($i = 0; $i < $latestCount; $i++)
-		{
-			$a = ClassRegistry::init('Achievement')->findById($latest[$i]['AchievementStatus']['achievement_id']);
-			$u = ClassRegistry::init('User')->findById($latest[$i]['AchievementStatus']['user_id']);
-			if (substr($u['User']['name'], 0, 3) == 'g__' && $u['User']['external_id'] != null)
-				$startPageUser = AppController::checkPicture($u['User']);
-			else
-				$startPageUser = $u['User']['name'];
-			$latest[$i]['AchievementStatus']['name'] = $a['Achievement']['name'];
-			$latest[$i]['AchievementStatus']['color'] = $a['Achievement']['color'];
-			$latest[$i]['AchievementStatus']['image'] = $a['Achievement']['image'];
-			$latest[$i]['AchievementStatus']['user'] = $startPageUser;
-			$result .= '<div class="quote1"><div class="quote1a"><a href="/achievements/view/' . $a['Achievement']['id'] . '"><img src="/img/' . $a['Achievement']['image'] . '.png" width="34px"></a></div>';
-			$result .= '<div class="quote1b">Achievement gained by ' . $startPageUser . ':<br><div class=""><b>' . $a['Achievement']['name'] . '</b></div></div></div>';
-		}
-		return $result;
-	}
-
 	/**
 	 * @param int $uid User ID
 	 * @param string $action Action type

--- a/src/Controller/SitesController.php
+++ b/src/Controller/SitesController.php
@@ -22,6 +22,7 @@ class SitesController extends AppController
 		$this->loadModel('Tsumego');
 		$this->loadModel('Set');
 		$this->loadModel('TsumegoStatus');
+		$this->loadModel('AchievementStatus');
 		$this->loadModel('User');
 		$this->loadModel('DayRecord');
 		$this->loadModel('Schedule');
@@ -58,6 +59,23 @@ class SitesController extends AppController
 		$this->set('quote', $currentQuote);
 		$this->set('dayRecord', $dayRecord);
 		$this->set('urNames', $urNames);
+
+		$recentAchievements = $this->AchievementStatus->getRecent();
+		$this->set('recentAchievements', $recentAchievements);
+	}
+
+	/**
+	 * Returns recent achievements for AJAX polling.
+	 *
+	 * @return void
+	 */
+	public function recentAchievements()
+	{
+		$this->autoRender = false;
+		$this->loadModel('AchievementStatus');
+		$this->response->type('json');
+		$recentAchievements = $this->AchievementStatus->getRecent();
+		$this->response->body(json_encode(['recentAchievements' => $recentAchievements]));
 	}
 
 	/**

--- a/src/Model/AchievementStatus.php
+++ b/src/Model/AchievementStatus.php
@@ -1,10 +1,59 @@
 <?php
 
+App::uses('AppController', 'Controller');
+
 class AchievementStatus extends AppModel
 {
 	public function __construct($id = false, $table = null, $ds = null)
 	{
 		$id['table'] =  'achievement_status';
 		parent::__construct($id, $table, $ds);
+	}
+
+	/**
+	 * Returns the most recent achievements with user and achievement details.
+	 *
+	 * @param int $limit Maximum number of results (default: 7)
+	 * @return array
+	 */
+	public function getRecent(int $limit = 7): array
+	{
+		$rows = $this->find('all', [
+			'joins' => [
+				[
+					'table' => 'achievement',
+					'alias' => 'Achievement',
+					'type' => 'INNER',
+					'conditions' => ['AchievementStatus.achievement_id = Achievement.id'],
+				],
+				[
+					'table' => 'user',
+					'alias' => 'User',
+					'type' => 'INNER',
+					'conditions' => ['AchievementStatus.user_id = User.id'],
+				],
+			],
+			'fields' => [
+				'AchievementStatus.id', 'AchievementStatus.created', 'Achievement.id', 'Achievement.name', 'Achievement.image',
+				'User.id', 'User.name', 'User.external_id',
+			],
+			'limit' => $limit,
+			'order' => 'AchievementStatus.created DESC',
+		]) ?: [];
+
+		$result = [];
+		foreach ($rows as $row)
+		{
+			$result[] = [
+				'status_id' => $row['AchievementStatus']['id'],
+				'id' => $row['Achievement']['id'],
+				'name' => $row['Achievement']['name'],
+				'image' => $row['Achievement']['image'],
+				'user_id' => (int) $row['User']['id'],
+				'user_name' => AppController::checkPicture($row['User']),
+				'created' => $row['AchievementStatus']['created'],
+			];
+		}
+		return $result;
 	}
 }

--- a/src/View/Sites/index.ctp
+++ b/src/View/Sites/index.ctp
@@ -315,7 +315,7 @@ $this->end();
 			if(Auth::isLoggedIn() && $ac) $modeActions = 'class="modeboxes" onmouseover="mode2hover()" onmouseout="modeNoHover()"';
 			if($ac) $modeActions2 = 'class="modeboxes"';
 			else $modeActions2 = 'class="modeboxes"';
-			echo '<div class="quote-pick-all quote-pick-'.$quotePick.'" id="ajaxWallpaper">'.AppController::getStartpage().'</div>';
+			echo '<div data-recent-achievements-root data-initial-achievements="'.h(json_encode($recentAchievements, JSON_HEX_QUOT | JSON_HEX_APOS)).'"></div>';
 		?>
 		<a href="/tsumegos/play/<?php echo (int)($_COOKIE['lastVisit'] ?? 15352); ?>?mode=1">
 			<div class="modeBox1" onmouseover="mode1hover()" onmouseout="modeNoHover()"></div>

--- a/tests/TestCase/Controller/SitesControllerTest.php
+++ b/tests/TestCase/Controller/SitesControllerTest.php
@@ -183,20 +183,62 @@ class SitesControllerTest extends ControllerTestCase
 	}
 
 	/**
-	 * Home page "Most Recent Achievements" should show the name of the user
-	 * who earned each achievement.
+	 * The landing page shows recent achievements in reverse chronological
+	 * order, limited to 7 rows for layout. Older entries are cut off.
 	 */
-	public function testHomePageShowsAchieverNames(): void
+	public function testHomePageShowsRecentAchievements(): void
 	{
-		$context = new ContextPreparator([
+		new ContextPreparator([
 			'other-users' => [
-				['name' => 'Alice', 'achievement-statuses' => [['id' => 1]]],
+				['name' => 'Alice', 'achievement-statuses' => [
+					['id' => 1, 'created' => '2026-01-01 12:00:00'],
+					['id' => 3, 'created' => '2026-01-03 12:00:00'],
+					['id' => 6, 'created' => '2026-01-06 12:00:00'],
+					['id' => 9, 'created' => '2026-01-09 12:00:00'],
+				]],
+				['name' => 'Bob', 'achievement-statuses' => [
+					['id' => 2, 'created' => '2026-01-02 12:00:00'],
+					['id' => 4, 'created' => '2026-01-04 12:00:00'],
+					['id' => 7, 'created' => '2026-01-07 12:00:00'],
+					['id' => 10, 'created' => '2026-01-10 12:00:00'],
+				]],
+				['name' => 'Charlie', 'achievement-statuses' => [
+					['id' => 5, 'created' => '2026-01-05 12:00:00'],
+					['id' => 8, 'created' => '2026-01-08 12:00:00'],
+				]],
 			],
 		]);
 		$browser = Browser::instance();
 		$browser->get('sites/index');
-		$pageSource = $browser->driver->getPageSource();
-		$this->assertStringContainsString('Achievement gained by Alice', $pageSource,
-			'Home page should show the name of the user who earned the achievement');
+
+		$rows = $browser->driver->findElements(WebDriverBy::cssSelector('.recent-achievement-row'));
+		$this->assertCount(7, $rows, 'Should show at most 7 achievements');
+
+		// Most recent first: Bob's 10000 Problems (Jan 10)
+		$this->assertStringContainsString('10000 Problems', $rows[0]->getText());
+		$this->assertStringContainsString('Bob', $rows[0]->getText());
+		$link = $rows[0]->findElement(WebDriverBy::cssSelector('.recent-achievement-achievement-link'));
+		$this->assertStringContainsString('/achievements/view/10', $link->getAttribute('href'));
+
+		// Second: Alice's 9000 Problems (Jan 9)
+		$this->assertStringContainsString('9000 Problems', $rows[1]->getText());
+		$this->assertStringContainsString('Alice', $rows[1]->getText());
+
+		// Third: Charlie's 8000 Problems (Jan 8)
+		$this->assertStringContainsString('8000 Problems', $rows[2]->getText());
+		$this->assertStringContainsString('Charlie', $rows[2]->getText());
+
+		// Verify reverse chronological order
+		$allText = implode("\n", array_map(fn($r) => $r->getText(), $rows));
+
+		// Oldest three (Jan 1-3) should be cut off by the limit of 7
+		$this->assertStringNotContainsString('3000 Problems', $allText);
+		$this->assertStringNotContainsString('2000 Problems', $allText);
+		$this->assertStringNotContainsString('1000 Problems', $allText);
+
+		// All three users appear in the visible rows
+		$this->assertStringContainsString('Alice', $allText);
+		$this->assertStringContainsString('Bob', $allText);
+		$this->assertStringContainsString('Charlie', $allText);
 	}
 }

--- a/webroot/css/default.css
+++ b/webroot/css/default.css
@@ -4528,9 +4528,7 @@ nav ul ul ul li {
 }
 .quote1b {
 }
-#ajaxWallpaper {
-  display: none;
-}
+
 #commentPosition {
   margin-top: 10px;
   margin-bottom: 17px;

--- a/webroot/css/home-themes.css
+++ b/webroot/css/home-themes.css
@@ -1,84 +1,89 @@
-.quote-pick-all {
+#recent-achievement-stream {
   font-size: 14px;
   position: absolute;
+  top: 280px;
+  left: 90px;
+  width: 460px;
 }
 
-.quote-pick-01 .quote1,
+#recent-achievement-stream .recent-achievement-row {
+  display: flex;
+  align-items: center;
+  padding: 5px 5px;
+  box-sizing: border-box;
+  background-color: rgba(0, 0, 0, 0.45);
+  color: #f5f5f5;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+}
+
+#recent-achievement-stream .recent-achievement-icon {
+  flex: 0 0 44px;
+}
+
+#recent-achievement-stream .recent-achievement-body {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+#recent-achievement-stream .recent-achievement-message {
+  min-width: 0;
+  overflow: hidden;
+  word-wrap: break-word;
+}
+
+#recent-achievement-stream .recent-achievement-message a {
+  color: #dcdcdc;
+  text-decoration: underline;
+}
+
+#recent-achievement-stream .recent-achievement-message a:hover {
+  color: #ffffff;
+}
+
+#recent-achievement-stream .recent-achievement-time {
+  color: #dcdcdc;
+  font-size: 12px;
+  margin-left: 12px;
+  white-space: nowrap;
+}
+
+
 .user-pick-q01 {
   color: white !important;
-}
-
-.quote-pick-01 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q01 {
   left: 316px;
   top: 172px;
   font-family: Comic Sans MS, Times New Roman, verdana;
 }
 
-.quote-pick-02 .quote1,
 .user-pick-q02 {
   color: #fdfdfd !important;
-}
-
-.quote-pick-02 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q02 {
   left: 316px;
   top: 106px;
   font-family: Impact, Times New Roman, verdana;
 }
 
-.quote-pick-03 .quote1,
 .user-pick-q03 {
   color: #e05d8f !important;
-}
-
-.quote-pick-03 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q03 {
   left: 316px;
   top: 89px;
   font-family: Lucida Console, Times New Roman, verdana;
 }
 
-.quote-pick-04 .quote1,
 .user-pick-q04 {
   color: #fdfdfe !important;
-}
-
-.quote-pick-04 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q04 {
   left: 316px;
   top: 189px;
   font-weight: bold;
   font-family: Baskerville, Times New Roman, verdana;
 }
 
-.quote-pick-05 .quote1,
 .user-pick-q05 {
   color: #fdfdfe !important;
-}
-
-.quote-pick-05 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q05 {
   left: 316px;
   top: 121px;
   font-size: 22px !important;
@@ -86,68 +91,32 @@
   font-family: Geneva, Times New Roman, verdana;
 }
 
-.quote-pick-06 .quote1,
 .user-pick-q06 {
   color: #ad935e !important;
-}
-
-.quote-pick-06 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q06 {
   left: 316px;
   top: 151px;
   font-weight: bold;
   font-family: Comic Sans MS, Times New Roman, verdana;
 }
 
-.quote-pick-07 .quote1,
 .user-pick-q07 {
   color: #fce1c2 !important;
-}
-
-.quote-pick-07 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q07 {
   left: 342px;
   top: 113px;
   font-weight: bold;
   font-family: Comic Sans MS, Times New Roman, verdana;
 }
 
-.quote-pick-08 .quote1,
 .user-pick-q08 {
   color: black !important;
-}
-
-.quote-pick-08 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q08 {
   left: 300px;
   top: 22px;
   font-weight: bold;
   font-family: Garamond, Times New Roman, verdana;
 }
 
-.quote-pick-09 .quote1,
 .user-pick-q09 {
   color: white !important;
-}
-
-.quote-pick-09 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q09 {
   left: 318px;
   top: 53px;
   font-family: Helvetica, Times New Roman, verdana;
@@ -155,68 +124,29 @@
 
 .user-pick-q10 {
   color: #fed487 !important;
-}
-
-.quote-pick-10 .quote1 {
-  color: #302f2d !important;
-}
-
-.quote-pick-10 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q10 {
   left: 317px;
   top: 153px;
   font-weight: bold;
   font-family: Helvetica, Times New Roman, verdana;
 }
 
-.quote-pick-11 .quote1,
 .user-pick-q11 {
   color: #fbcc5f !important;
-}
-
-.quote-pick-11 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q11 {
   left: 321px;
   top: 125px;
   font-size: 15px;
   font-family: Helvetica, Times New Roman, verdana;
 }
 
-.quote-pick-12 .quote1,
 .user-pick-q12 {
   color: #b83330 !important;
-}
-
-.quote-pick-12 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q12 {
   left: 321px;
   top: 145px;
   font-family: Helvetica, Times New Roman, verdana;
 }
 
-.quote-pick-13 .quote1,
 .user-pick-q13 {
   color: white !important;
-}
-
-.quote-pick-13 {
-  top: 288px;
-  left: 100px;
-}
-
-.user-pick-q13 {
   left: 321px;
   top: 118px;
   font-family: Helvetica, Times New Roman, verdana;


### PR DESCRIPTION
original this was fetched using ajax from mainPageAjax.txt into ajaxWallpaper 
then in 690039c4f it was rewritten to use db, but the ajaxWallpaper stayed and css kept it invisible

<img width="502" height="398" alt="image" src="https://github.com/user-attachments/assets/0ea5f0d8-5ece-420c-8014-01908f7466e2" />


original solution by Joschka was most likely basically server side rendered cached html.
this refetches every 60 sec, we could add manual cache or partition on achievment_status.created or in new cakephp use a query cache, but it's most likely not necessary, there is already index on the created column

also the 60 seconds poll might be overkill, peak achievements is like 1 per 5 minutes, not sure if anyone will really have this page open for 5 minutes to justify reactivity, but it's basically free