### PR TITLE
fix: remove dead about-page queries loading 14K tsumegos

### DIFF
--- a/src/Controller/SitesController.php
+++ b/src/Controller/SitesController.php
@@ -128,75 +128,8 @@ class SitesController extends AppController
 	 */
 	public function about()
 	{
-		$this->loadModel('User');
-		$this->loadModel('Tsumego');
-		$this->loadModel('Set');
-
 		$this->set('_page', 'about');
 		$this->set('_title', 'Tsumego Hero - About');
-
-		$authors = $this->Tsumego->find('all', [
-			'order' => 'created DESC',
-			'conditions' => [
-				'NOT' => [
-					'author' => ['Joschka Zimdars'],
-				],
-			],
-		]);
-		$set = $this->Set->find('all');
-		$setMap = [];
-		$setMap2 = [];
-		$setCount = count($set);
-		for ($i = 0; $i < $setCount; $i++)
-		{
-			$divider = ' ';
-			$setMap[$set[$i]['Set']['id']] = $set[$i]['Set']['title'] . $divider . $set[$i]['Set']['title2'];
-			$setMap2[$set[$i]['Set']['id']] = $set[$i]['Set']['public'];
-		}
-
-		$count = [];
-		$count[0]['author'] = 'Innokentiy Zabirov';
-		$count[0]['collections'] = 's: <a href="/sets/view/41">Life & Death - Intermediate</a> and <a href="/sets/view/122">Gokyo Shumyo 1-4</a>';
-		$count[0]['count'] = 0;
-		$count[1]['author'] = 'Alexandre Dinerchtein';
-		$count[1]['collections'] = ': <a href="/sets/view/109">Problems from Professional Games</a>';
-		$count[1]['count'] = 0;
-		$count[2]['author'] = 'David Ulbricht';
-		$count[2]['collections'] = ': <a href="/sets/view/41">Life & Death - Intermediate</a>';
-		$count[2]['count'] = 0;
-		$count[3]['author'] = 'Bradford Malbon';
-		$count[3]['collections'] = 's: <a href="/sets/view/104">Easy Life</a> and <a href="/sets/view/105">Easy Kill</a>';
-		$count[3]['count'] = 0;
-		$count[4]['author'] = 'Ryan Smith';
-		$count[4]['collections'] = 's: <a href="/sets/view/67">Korean Problem Academy 1-4</a>';
-		$count[4]['count'] = 0;
-		$count[5]['author'] = 'Fupfv';
-		$count[5]['collections'] = ': <a href="/sets/view/139">Gokyo Shumyo 4</a>';
-		$count[5]['count'] = 0;
-		$count[6]['author'] = 'саша черных';
-		$count[6]['collections'] = ': <a href="/sets/view/137">Tsumego Master</a>';
-		$count[6]['count'] = 0;
-		$count[7]['author'] = 'Timo Kreuzer';
-		$count[7]['collections'] = ': <a href="/sets/view/137">Tsumego Master</a>';
-		$count[7]['count'] = 0;
-		$count[8]['author'] = 'David Mitchell';
-		$count[8]['collections'] = ': <a href="/sets/view/143">Diabolical</a>';
-		$count[8]['count'] = 10;
-		$count[9]['author'] = 'Omicron';
-		$count[9]['collections'] = ': <a href="/sets/view/145">Tesujis in Real Board Positions</a>';
-		$count[9]['count'] = 0;
-		$count[10]['author'] = 'Sadaharu';
-		$count[10]['collections'] = ': <a href="/sets/view/146">Tsumego of Fortitude</a>, <a href="/sets/view/166">Secret Tsumego from Hong Dojo</a>, <a href="/sets/view/158">Beautiful Tsumego</a> and more.';
-		$count[10]['count'] = 0;
-		$count[11]['author'] = 'Jérôme Hubert';
-		$count[11]['collections'] = ': <a href="/sets/view/150">Kanzufu</a> and more.';
-		$count[11]['count'] = 0;
-		$count[12]['author'] = 'Kaan Malçok';
-		$count[12]['collections'] = ': <a href="/sets/view/163">Xuanxuan Qijing</a>';
-		$count[12]['count'] = 0;
-
-		$this->set('count', $count);
-		$this->set('t', $authors);
 	}
 
 	/**


### PR DESCRIPTION
The page is static so the query is useless, we could easily make an aggregate query that would count this, but some of the users from the list have multiple accounts, and some are not in db.